### PR TITLE
Disallow NaN from table

### DIFF
--- a/romanesco/format/__init__.py
+++ b/romanesco/format/__init__.py
@@ -3,6 +3,7 @@ import json
 import glob
 import os
 import romanesco.uri
+import math
 from StringIO import StringIO
 
 
@@ -124,7 +125,13 @@ def csv_to_rows(input):
                 row[col] = int(row[col])
             except:
                 try:
+                    orig = row[col]
                     row[col] = float(row[col])
+
+                    # Disallow NaN, Inf, -Inf since this does not
+                    # pass through JSON converters cleanly
+                    if math.isnan(row[col]) or math.isinf(row[col]):
+                        row[col] = orig
                 except:
                     pass
 

--- a/tests/table_test.py
+++ b/tests/table_test.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 import collections
 import vtk
+import json
+import math
 
 
 class TestTable(unittest.TestCase):
@@ -342,6 +344,27 @@ class TestTable(unittest.TestCase):
             "GLCM_autocorr", "GLCM_clusProm", "GLCM_clusShade"
         ])
         self.assertEqual(len(output["data"]["rows"]), 99)
+
+    def test_nan(self):
+        output = romanesco.convert(
+            "table",
+            {
+                "format": "csv",
+                "uri": "file://" + os.path.join("data", "RadiomicsData.csv")
+            },
+            {"format": "rows.json"}
+        )
+        data = json.loads(output["data"])
+        self.assertEqual(len(data["fields"]), 454)
+        self.assertEqual(data["fields"][:3], [
+            "GLCM_autocorr", "GLCM_clusProm", "GLCM_clusShade"
+        ])
+        self.assertEqual(len(data["rows"]), 99)
+        for row in data["rows"]:
+            for field in row:
+                if isinstance(row[field], float):
+                    self.assertFalse(math.isnan(row[field]))
+                    self.assertFalse(math.isinf(row[field]))
 
     def test_vector(self):
         rows = {


### PR DESCRIPTION
Because Python's json.dumps does not deal with NaNs cleanly
