### PR TITLE
Add shortcut from CSV to column names

### DIFF
--- a/romanesco/format/table/csv_to_column_names.json
+++ b/romanesco/format/table/csv_to_column_names.json
@@ -1,0 +1,7 @@
+{
+    "name": "CSV to Column Names",
+    "inputs": [{"name": "input", "type": "table", "format": "csv"}],
+    "outputs": [{"name": "output", "type": "table", "format": "column.names"}],
+    "script_uri": "file://csv_to_column_names.py",
+    "mode": "python"
+}

--- a/romanesco/format/table/csv_to_column_names.py
+++ b/romanesco/format/table/csv_to_column_names.py
@@ -1,5 +1,5 @@
-import cStringIO
+from six import StringIO
 from romanesco.format import csv_to_rows
 
-first_line = cStringIO.StringIO(input).readline()
+first_line = StringIO(input).readline()
 output = csv_to_rows(first_line)['fields']

--- a/romanesco/format/table/csv_to_column_names.py
+++ b/romanesco/format/table/csv_to_column_names.py
@@ -1,0 +1,5 @@
+import cStringIO
+from romanesco.format import csv_to_rows
+
+first_line = cStringIO.StringIO(input).readline()
+output = csv_to_rows(first_line)['fields']

--- a/tests/table_test.py
+++ b/tests/table_test.py
@@ -285,6 +285,14 @@ class TestTable(unittest.TestCase):
         self.assertEqual(output["format"], "column.names")
         self.assertEqual(output["data"], ["a", "b"])
 
+    def test_column_names_csv(self):
+        output = romanesco.convert("table", {
+            "format": "csv",
+            "data": ",a,b,longer name\n1,1,1,1\n2,2,2,2\n3,3,3,3\n"
+        }, {"format": "column.names"})
+        self.assertEqual(output["format"], "column.names")
+        self.assertEqual(output["data"], ["", "a", "b", "longer name"])
+
     def test_column_names_discrete(self):
         output = romanesco.convert("table", {
             "format": "rows",


### PR DESCRIPTION
Does not require walking through the entire dataset