### PR TITLE
Test environment should not take plugins enabled value from cfg file

### DIFF
--- a/tests/PythonTests.cmake
+++ b/tests/PythonTests.cmake
@@ -64,6 +64,10 @@ function(add_python_test case)
     set_property(TEST ${name} PROPERTY ENVIRONMENT
       "ROMANESCO_PLUGINS_ENABLED=${fn_PLUGINS_ENABLED}"
     )
+  else()
+    set_property(TEST ${name} PROPERTY ENVIRONMENT
+      "ROMANESCO_PLUGINS_ENABLED="
+    )
   endif()
 endfunction()
 


### PR DESCRIPTION
This was breaking some tests in development environments where plugins
were enabled.