### PR TITLE
Make Configuration one level lower in docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ romanesco is already installed.
 .. _configuration:
 
 Configuration
-=============
+-------------
 
 Several aspects of Romanesco's behavior are controlled via its configuration file. This
 file is found within the installed package directory as ``worker.local.cfg``. If this


### PR DESCRIPTION
Without this Sphinx makes a top-level item on the left that does not highlight when clicked. I think there is only supposed to be one top-level Sphinx heading per page.