### PR TITLE
[Suggestion]  Change custom module to __romanesco__

### DIFF
--- a/romanesco/executors/python.py
+++ b/romanesco/executors/python.py
@@ -5,7 +5,7 @@ import tempfile
 
 
 def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
-    custom = imp.new_module("custom")
+    custom = imp.new_module("__romanesco__")
 
     custom.__dict__['_job_manager'] = kwargs.get('_job_manager')
 

--- a/romanesco/plugins/spark/pyspark_executor.py
+++ b/romanesco/plugins/spark/pyspark_executor.py
@@ -6,7 +6,7 @@ import sys
 def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
     from . import SC_KEY
 
-    custom = imp.new_module("custom")
+    custom = imp.new_module("__romanesco__")
 
     sc = kwargs[SC_KEY]
     custom.__dict__['sc'] = sc


### PR DESCRIPTION
Changing the python/spark.python executors to use ```__romanesco__``` instead of ```custom``` makes writing tasks that are meant to be run from either romanesco or the command line a little more aesthetically pleasing:

```python
import argparse
from some import module

def my_great_analysis_code(foo, bar):
    # great code goes here

if __name__ == "__romanesco__":
    my_great_analysis_code(foo, bar)

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("foo")
    parser.add_argument("bar")
    args = parser.parse_args()
    my_great_analysis_code(args.foo, args.bar)
```

Currently one would have to write:

```python
import argparse
from some import module

def my_great_analysis_code(foo, bar):
    # great code goes here

if __name__ == "custom":
    my_great_analysis_code(foo, bar)

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("foo")
    parser.add_argument("bar")
    args = parser.parse_args()
    my_great_analysis_code(args.foo, args.bar)
```