### PR TITLE
Conversion Graph Cleanup

### DIFF
--- a/romanesco/__init__.py
+++ b/romanesco/__init__.py
@@ -3,7 +3,7 @@ import os
 import romanesco.events
 import romanesco.format
 import romanesco.io
-from romanesco.format import converter_path, get_validator, Validator
+from romanesco.format import converter_path, get_validator_analysis, Validator
 from ConfigParser import ConfigParser
 from executors.python import run as python_run
 from executors.workflow import run as workflow_run
@@ -102,8 +102,8 @@ def isvalid(type, binding, **kwargs):
     """
     if "data" not in binding:
         binding["data"] = romanesco.io.fetch(binding, **kwargs)
-    validator = get_validator(Validator(type, binding["format"]))[1]
-    outputs = romanesco.run(validator, {"input": binding}, auto_convert=False,
+    analysis = get_validator_analysis(Validator(type, binding["format"]))
+    outputs = romanesco.run(analysis, {"input": binding}, auto_convert=False,
                             validate=False, **kwargs)
     return outputs["output"]["data"]
 
@@ -193,9 +193,6 @@ def run(task, inputs, outputs=None, auto_convert=True, validate=True,
     """
     def extractId(spec):
         return spec["id"] if "id" in spec else spec["name"]
-
-    if 'validator' in task:
-        task = task['validator']
 
     task_inputs = {extractId(d): d for d in task.get("inputs", ())}
     task_outputs = {extractId(d): d for d in task.get("outputs", ())}

--- a/romanesco/format/__init__.py
+++ b/romanesco/format/__init__.py
@@ -6,6 +6,7 @@ import math
 import romanesco.io
 import networkx as nx
 from collections import namedtuple
+from networkx.exception import NetworkXNoPath
 from networkx.algorithms.shortest_paths.generic import all_shortest_paths
 from networkx.algorithms.shortest_paths.unweighted import single_source_shortest_path
 
@@ -86,9 +87,12 @@ def converter_path(source, target):
     :returns: An ordered list of the analyses that need to be run to convert from
     ``source`` to ``target``.
     """
-    # These are to ensure an exception gets thrown if source/target don't exist
-    get_validator_analysis(source)
-    get_validator_analysis(target)
+    # Ensure an exception gets thrown if source/target don't exist
+    try:
+        get_validator_analysis(source)
+        get_validator_analysis(target)
+    except:
+        raise NetworkXNoPath
 
     # We sort and pick the first of the shortest paths just to produce a stable
     # conversion path. This is stable in regards to which plugins are loaded at the

--- a/romanesco/format/__init__.py
+++ b/romanesco/format/__init__.py
@@ -211,6 +211,8 @@ def import_converters(search_paths):
         for filename in validator_files:
             analysis = get_analysis(filename)
 
+            # Validators only contain 1 input and output, so the type/format of
+            # it can be gleaned from the first input.
             conv_graph.add_node(Validator(analysis["inputs"][0]["type"],
                                           analysis["inputs"][0]["format"]),
                                 analysis)

--- a/romanesco/plugins/vtk/converters/graph/networkx_to_vtkgraph.py
+++ b/romanesco/plugins/vtk/converters/graph/networkx_to_vtkgraph.py
@@ -1,4 +1,5 @@
 from romanesco.plugins.vtk import dict_to_vtkarrays, dict_to_vtkrow
+import six
 import vtk
 
 """
@@ -53,12 +54,12 @@ for (_, _, data) in edges:
 
 # Merge default attributes into nodes and edges
 for (_, data) in nodes:
-    for (field, field_type) in node_field_types.iteritems():
+    for (field, field_type) in six.iteritems(node_field_types):
         if field not in data:
             data[field] = field_type()
 
 for (_, _, data) in edges:
-    for (field, field_type) in edge_field_types.iteritems():
+    for (field, field_type) in six.iteritems(edge_field_types):
         if field not in data:
             data[field] = field_type()
 

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -4,7 +4,7 @@ import unittest
 from romanesco.format import converter_path, has_converter, Validator, \
     print_conversion_graph, print_conversion_table
 from six import StringIO
-from networkx import NetworkXNoPath
+from networkx.exception import NetworkXNoPath
 
 
 class TestFormat(unittest.TestCase):
@@ -18,11 +18,12 @@ class TestFormat(unittest.TestCase):
         sys.stdout = self.prev_stdout
 
     def test_converter_path(self):
-        with self.assertRaisesRegexp(Exception,
-                                     'No such validator foo/bar'):
+        # There is no path from validators that don't exist
+        with self.assertRaises(NetworkXNoPath):
             converter_path(Validator('foo', 'bar'),
                            Validator('foo', 'baz'))
 
+        # There is no path for types which lie in different components
         with self.assertRaises(NetworkXNoPath):
             converter_path(self.stringTextValidator,
                            Validator('graph', 'networkx'))


### PR DESCRIPTION
From f5de399:
> Removing O(n) calls over NetworkX edges/nodes in favor of O(1) calls
through their built-in data structures.

> Removing node metadata that was never actually being used.

> Simplifies get_validator so it just returns the runnable analysis.

Also fixed a couple of instances where I wasn't using ```six```.