### PR TITLE
Fix Sphinx Build Errors/Warnings

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -237,9 +237,3 @@ Formats
 
 .. automodule:: romanesco.format
    :members:
-
-URIs
-----
-
-.. automodule:: romanesco.uri
-   :members:

--- a/romanesco/format/__init__.py
+++ b/romanesco/format/__init__.py
@@ -85,7 +85,7 @@ def converter_path(source, target):
     :param source: Validator tuple indicating the type/format being converted `from`.
     :param target: ``Validator`` tuple indicating the type/format being converted `to`.
     :returns: An ordered list of the analyses that need to be run to convert from
-    ``source`` to ``target``.
+        ``source`` to ``target``.
     """
     # Ensure an exception gets thrown if source/target don't exist
     try:
@@ -113,7 +113,7 @@ def has_converter(source, target=Validator(type=None, format=None)):
     :param source: ``Validator`` tuple indicating the type/format being converted `from`.
     :param target: ``Validator`` tuple indicating the type/format being converted `to`.
     :returns: ``True`` if it can converter from ``source`` to ``target``, ``False``
-    otherwise.
+        otherwise.
     """
     sources = []
 
@@ -150,7 +150,7 @@ def get_validator_analysis(validator):
     If the validator doesn't exist, an exception will be raised
     >>> get_validator_analysis(Validator('foo', 'bar'))
     Traceback (most recent call last):
-       ...
+    ...
     Exception: No such validator foo/bar
 
     :param validator: A ``Validator`` namedtuple


### PR DESCRIPTION
Master ```make html``` from /docs throws the following errors:
```
/home/dan/projects/romanesco/romanesco/format/__init__.py:docstring of romanesco.format.converter_path:9: WARNING: Field list ends without a blank line; unexpected unindent.
/home/dan/projects/romanesco/romanesco/format/__init__.py:docstring of romanesco.format.get_validator_analysis:16: ERROR: Unexpected indentation.
/home/dan/projects/romanesco/romanesco/format/__init__.py:docstring of romanesco.format.get_validator_analysis:17: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/dan/projects/romanesco/romanesco/format/__init__.py:docstring of romanesco.format.has_converter:9: WARNING: Field list ends without a blank line; unexpected unindent.
/home/dan/projects/romanesco/docs/api-docs.rst:244: WARNING: autodoc: failed to import module u'romanesco.uri'; the following exception was raised:
Traceback (most recent call last):
  File "/home/dan/.virtualenvs/romanesco/local/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 385, in import_object
    __import__(self.modname)
ImportError: No module named uri
```

This branch resolves those.