### PR TITLE
Minimal swift integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
   - wget http://swiftlang.org/packages/swift-0.96.1.tar.gz
   - tar xfz swift-0.96.1.tar.gz
   - export PATH=$PATH:$HOME/swift-0.96.1/bin
+  - swift --version
 
 # install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ before_install:
   - wget http://swiftlang.org/packages/swift-0.96.1.tar.gz
   - tar xfz swift-0.96.1.tar.gz
   - export PATH=$PATH:$HOME/swift-0.96.1/bin
+  - echo $HOME
+  - echo $PWD
   - swift --version
 
 # install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ before_install:
   - $SPARK_HOME/sbin/start-master.sh
   - sleep 3
   - $SPARK_HOME/sbin/start-slave.sh worker1 spark://localhost:7077
+  # install swift
+  - wget http://swiftlang.org/packages/swift-0.96.1.tar.gz
+  - tar xfz swift-0.96.1.tar.gz
+  - export PATH=$PATH:$HOME/swift-0.96/bin
 
 # install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   # install swift
   - wget http://swiftlang.org/packages/swift-0.96.1.tar.gz
   - tar xfz swift-0.96.1.tar.gz
-  - export PATH=$PATH:$HOME/swift-0.96/bin
+  - export PATH=$PATH:$HOME/swift-0.96.1/bin
 
 # install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,8 @@ before_install:
   - $SPARK_HOME/sbin/start-slave.sh worker1 spark://localhost:7077
   # install swift
   - wget http://swiftlang.org/packages/swift-0.96.1.tar.gz
-  - tar xfz swift-0.96.1.tar.gz
+  - tar xfz swift-0.96.1.tar.gz -C ~
   - export PATH=$PATH:$HOME/swift-0.96.1/bin
-  - echo $HOME
-  - echo $PWD
   - swift --version
 
 # install dependencies

--- a/romanesco/plugins/docker/executor.py
+++ b/romanesco/plugins/docker/executor.py
@@ -1,8 +1,7 @@
 import os
 import re
-import select
+import romanesco.utils
 import subprocess
-import sys
 
 
 def _pull_image(image):
@@ -62,39 +61,6 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
     return newArgs
 
 
-def _run_docker_process(command, outputs, print_stdout, print_stderr):
-    p = subprocess.Popen(args=command, stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
-    fds = [p.stdout, p.stderr]
-    while True:
-        ready = select.select(fds, (), fds, 1)[0]
-
-        if p.stdout in ready:
-            buf = os.read(p.stdout.fileno(), 1024)
-            if buf:
-                if print_stdout:
-                    sys.stdout.write(buf)
-                else:
-                    outputs['_stdout']['script_data'] += buf
-            else:
-                fds.remove(p.stdout)
-        if p.stderr in ready:
-            buf = os.read(p.stderr.fileno(), 1024)
-            if buf:
-                if print_stderr:
-                    sys.stderr.write(buf)
-                else:
-                    outputs['_stderr']['script_data'] += buf
-            else:
-                fds.remove(p.stderr)
-        if (not fds or not ready) and p.poll() is not None:
-            break
-        elif not fds and p.poll() is None:
-            p.wait()
-
-    return p
-
-
 def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
     image = task['docker_image']
     print('Pulling docker image: ' + image)
@@ -124,7 +90,8 @@ def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
 
     print('Running container: "%s"' % ' '.join(command))
 
-    p = _run_docker_process(command, outputs, print_stdout, print_stderr)
+    p = romanesco.utils.run_process(command, outputs,
+                                    print_stdout, print_stderr)
 
     if p.returncode != 0:
         raise Exception('Error: docker run returned code {}.'.format(

--- a/romanesco/plugins/docker/tests/docker_test.py
+++ b/romanesco/plugins/docker/tests/docker_test.py
@@ -16,7 +16,7 @@ _err = six.StringIO('error message')
 # Monkey patch select.select in the docker task module
 def _mockSelect(r, w, x, *args, **kwargs):
     return r, w, x
-romanesco.plugins.docker.executor.select.select = _mockSelect
+romanesco.utils.select.select = _mockSelect
 
 
 # Monkey patch os.read to simulate subprocess stdout and stderr

--- a/romanesco/plugins/swift/__init__.py
+++ b/romanesco/plugins/swift/__init__.py
@@ -1,0 +1,6 @@
+import romanesco
+from . import executor
+
+
+def load(params):
+    romanesco.register_executor('swift', executor.run)

--- a/romanesco/plugins/swift/executor.py
+++ b/romanesco/plugins/swift/executor.py
@@ -1,8 +1,6 @@
 import os
 import re
-import select
-import subprocess
-import sys
+import romanesco.utils
 import tempfile
 
 
@@ -46,39 +44,6 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
     return newArgs
 
 
-def _run_swift_process(command, outputs, print_stdout, print_stderr):
-    p = subprocess.Popen(args=command, stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
-    fds = [p.stdout, p.stderr]
-    while True:
-        ready = select.select(fds, (), fds, 1)[0]
-
-        if p.stdout in ready:
-            buf = os.read(p.stdout.fileno(), 1024)
-            if buf:
-                if print_stdout:
-                    sys.stdout.write(buf)
-                else:
-                    outputs['_stdout']['script_data'] += buf
-            else:
-                fds.remove(p.stdout)
-        if p.stderr in ready:
-            buf = os.read(p.stderr.fileno(), 1024)
-            if buf:
-                if print_stderr:
-                    sys.stderr.write(buf)
-                else:
-                    outputs['_stderr']['script_data'] += buf
-            else:
-                fds.remove(p.stderr)
-        if (not fds or not ready) and p.poll() is not None:
-            break
-        elif not fds and p.poll() is None:
-            p.wait()
-
-    return p
-
-
 def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
     script = task['script']
     script_fname = tempfile.mktemp()
@@ -101,7 +66,8 @@ def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
 
     print('Running swift: "%s"' % ' '.join(command))
 
-    p = _run_swift_process(command, outputs, print_stdout, print_stderr)
+    p = romanesco.utils.run_process(command, outputs,
+                                    print_stdout, print_stderr)
 
     if p.returncode != 0:
         raise Exception('Error: swift run returned code {}.'.format(

--- a/romanesco/plugins/swift/executor.py
+++ b/romanesco/plugins/swift/executor.py
@@ -1,4 +1,3 @@
-import os
 import re
 import romanesco.utils
 import tempfile

--- a/romanesco/plugins/swift/executor.py
+++ b/romanesco/plugins/swift/executor.py
@@ -1,0 +1,112 @@
+import os
+import re
+import select
+import subprocess
+import sys
+import tempfile
+
+
+def _transform_path(inputs, taskInputs, inputId, tmpDir):
+    """
+    If the input specified by inputId is a filepath target, we transform it to
+    its absolute path within the docker container (underneath /data).
+    """
+    for ti in taskInputs.itervalues():
+        tiId = ti['id'] if 'id' in ti else ti['name']
+        if tiId == inputId:
+            if ti.get('target') == 'filepath':
+                rel = os.path.relpath(inputs[inputId]['script_data'], tmpDir)
+                return os.path.join('/data', rel)
+            else:
+                return inputs[inputId]['script_data']
+
+    raise Exception('No task input found with id = ' + inputId)
+
+
+def _expand_args(args, inputs, taskInputs, tmpDir):
+    """
+    Expands arguments to the container execution if they reference input
+    data. For example, if an input has id=foo, then a container arg of the form
+    $input{foo} would be expanded to the runtime value of that input. If that
+    input is a filepath target, the file path will be transformed into the
+    location that it will be available inside the running container.
+    """
+    newArgs = []
+    regex = re.compile(r'\$input\{([^}]+)\}')
+
+    for arg in args:
+        for inputId in re.findall(regex, arg):
+            if inputId in inputs:
+                transformed = _transform_path(inputs, taskInputs, inputId,
+                                              tmpDir)
+                arg = arg.replace('$input{%s}' % inputId, transformed)
+
+        newArgs.append(arg)
+
+    return newArgs
+
+
+def _run_swift_process(command, outputs, print_stdout, print_stderr):
+    p = subprocess.Popen(args=command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    fds = [p.stdout, p.stderr]
+    while True:
+        ready = select.select(fds, (), fds, 1)[0]
+
+        if p.stdout in ready:
+            buf = os.read(p.stdout.fileno(), 1024)
+            if buf:
+                if print_stdout:
+                    sys.stdout.write(buf)
+                else:
+                    outputs['_stdout']['script_data'] += buf
+            else:
+                fds.remove(p.stdout)
+        if p.stderr in ready:
+            buf = os.read(p.stderr.fileno(), 1024)
+            if buf:
+                if print_stderr:
+                    sys.stderr.write(buf)
+                else:
+                    outputs['_stderr']['script_data'] += buf
+            else:
+                fds.remove(p.stderr)
+        if (not fds or not ready) and p.poll() is not None:
+            break
+        elif not fds and p.poll() is None:
+            p.wait()
+
+    return p
+
+
+def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
+    script = task['script']
+    script_fname = tempfile.mktemp()
+    with open(script_fname, 'w') as script_file:
+        script_file.write(script)
+
+    tmpDir = kwargs.get('_tmp_dir')
+    args = _expand_args(task['swift_args'], inputs, task_inputs, tmpDir)
+
+    print_stderr, print_stdout = True, True
+    for id, to in task_outputs.iteritems():
+        if id == '_stderr':
+            outputs['_stderr']['script_data'] = ''
+            print_stderr = False
+        elif id == '_stdout':
+            outputs['_stdout']['script_data'] = ''
+            print_stdout = False
+
+    command = ['swift', script_fname] + args
+
+    print('Running swift: "%s"' % ' '.join(command))
+
+    p = _run_swift_process(command, outputs, print_stdout, print_stderr)
+
+    if p.returncode != 0:
+        raise Exception('Error: swift run returned code {}.'.format(
+                        p.returncode))
+
+    for name, task_output in task_outputs.iteritems():
+        with open(name) as output_file:
+            outputs[name]['script_data'] = output_file.read()

--- a/romanesco/plugins/swift/plugin.cmake
+++ b/romanesco/plugins/swift/plugin.cmake
@@ -1,0 +1,1 @@
+add_python_test(swift PLUGIN swift PLUGINS_ENABLED swift)

--- a/romanesco/plugins/swift/tests/swift_test.py
+++ b/romanesco/plugins/swift/tests/swift_test.py
@@ -1,5 +1,24 @@
+import os
 import romanesco
+import shutil
 import unittest
+
+
+def setUpModule():
+    global _tmp
+    global _cwd
+    _cwd = os.getcwd()
+    _tmp = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), 'tmp', 'swift')
+    if not os.path.isdir(_tmp):
+        os.makedirs(_tmp)
+    os.chdir(_tmp)
+
+
+def tearDownModule():
+    os.chdir(_cwd)
+    if os.path.isdir(_tmp):
+        shutil.rmtree(_tmp)
 
 
 class TestSwiftMode(unittest.TestCase):

--- a/romanesco/plugins/swift/tests/swift_test.py
+++ b/romanesco/plugins/swift/tests/swift_test.py
@@ -39,10 +39,8 @@ out = echo_app(strcat("a,b,c\\n", a, ",2,3"));
             }
         }
 
-        # Use user-specified filename
         out = romanesco.run(task, inputs=inputs)
 
-        # We bound _stderr as a task output, so it should be in the output
         self.assertEqual(out, {
             'out.csv': {
                 'data': 'a,b,c\n5,2,3\n',

--- a/romanesco/plugins/swift/tests/swift_test.py
+++ b/romanesco/plugins/swift/tests/swift_test.py
@@ -1,0 +1,51 @@
+import romanesco
+import unittest
+
+
+class TestSwiftMode(unittest.TestCase):
+    def testSwiftMode(self):
+        task = {
+            'mode': 'swift',
+            'script': """
+type file;
+
+app (file out) echo_app (string s)
+{
+   echo s stdout=filename(out);
+}
+
+string a = arg("a", "10");
+
+file out <"out.csv">;
+out = echo_app(strcat("a,b,c\\n", a, ",2,3"));
+""",
+            'inputs': [{
+                'id': 'a',
+                'format': 'json',
+                'type': 'number'
+            }],
+            'swift_args': ['-a=$input{a}'],
+            'outputs': [{
+                'id': 'out.csv',
+                'type': 'table',
+                'format': 'csv'
+            }]
+        }
+
+        inputs = {
+            'a': {
+                'format': 'number',
+                'data': 5
+            }
+        }
+
+        # Use user-specified filename
+        out = romanesco.run(task, inputs=inputs)
+
+        # We bound _stderr as a task output, so it should be in the output
+        self.assertEqual(out, {
+            'out.csv': {
+                'data': 'a,b,c\n5,2,3\n',
+                'format': 'csv'
+            }
+        })


### PR DESCRIPTION
Creates “swift” mode for http://swift-lang.org/ (not Apple’s swift). Support basic file output and basic string argument-based input, which seems to be a main use case.

This only works local, there are .conf files that can be used to setup swift on supercomputers that we would want to support.