### PR TITLE
Pythonic interface to workflows

### DIFF
--- a/romanesco/specs/__init__.py
+++ b/romanesco/specs/__init__.py
@@ -2,7 +2,8 @@ from .spec import Spec
 from .port import Port, ValidationError
 from .port_list import PortList
 from .task import Task, TaskSpec, ReadOnlyAttributeException
-from .workflow import Workflow
+from .workflow import Workflow, StepSpec, WorkflowException, DuplicateTaskException
 
 __all__ = ('Spec', 'Port', 'PortList', 'ValidationError',
-           'TaskSpec', 'Task', 'ReadOnlyAttributeException', "Workflow")
+           'TaskSpec', 'Task', 'ReadOnlyAttributeException',
+           "Workflow", "StepSpec", "WorkflowException", "DuplicateTaskException")

--- a/romanesco/specs/__init__.py
+++ b/romanesco/specs/__init__.py
@@ -1,8 +1,8 @@
 from .spec import Spec
 from .port import Port, ValidationError
 from .port_list import PortList
-from .task import Task, AnonymousTask, ReadOnlyAttributeException
+from .task import Task, TaskSpec, ReadOnlyAttributeException
 
 
 __all__ = ('Spec', 'Port', 'PortList', 'ValidationError',
-           'AnonymousTask', 'Task', 'ReadOnlyAttributeException')
+           'TaskSpec', 'Task', 'ReadOnlyAttributeException')

--- a/romanesco/specs/__init__.py
+++ b/romanesco/specs/__init__.py
@@ -1,7 +1,8 @@
 from .spec import Spec
 from .port import Port, ValidationError
 from .port_list import PortList
-from .task import Task
+from .task import Task, AnonymousTask, ReadOnlyAttributeException
 
 
-__all__ = ('Spec', 'Port', 'PortList', 'ValidationError', 'Task')
+__all__ = ('Spec', 'Port', 'PortList', 'ValidationError',
+           'AnonymousTask', 'Task', 'ReadOnlyAttributeException')

--- a/romanesco/specs/__init__.py
+++ b/romanesco/specs/__init__.py
@@ -2,7 +2,7 @@ from .spec import Spec
 from .port import Port, ValidationError
 from .port_list import PortList
 from .task import Task, TaskSpec, ReadOnlyAttributeException
-
+from .workflow import Workflow
 
 __all__ = ('Spec', 'Port', 'PortList', 'ValidationError',
-           'TaskSpec', 'Task', 'ReadOnlyAttributeException')
+           'TaskSpec', 'Task', 'ReadOnlyAttributeException', "Workflow")

--- a/romanesco/specs/__init__.py
+++ b/romanesco/specs/__init__.py
@@ -2,8 +2,10 @@ from .spec import Spec
 from .port import Port, ValidationError
 from .port_list import PortList
 from .task import Task, TaskSpec, ReadOnlyAttributeException
-from .workflow import Workflow, StepSpec, WorkflowException, DuplicateTaskException
+from .workflow import Workflow, StepSpec, ConnectionSpec
+from .workflow import WorkflowException, DuplicateTaskException
 
 __all__ = ('Spec', 'Port', 'PortList', 'ValidationError',
            'TaskSpec', 'Task', 'ReadOnlyAttributeException',
-           "Workflow", "StepSpec", "WorkflowException", "DuplicateTaskException")
+           "Workflow", "StepSpec", "ConnectionSpec",
+           "WorkflowException", "DuplicateTaskException")

--- a/romanesco/specs/spec.py
+++ b/romanesco/specs/spec.py
@@ -3,6 +3,7 @@
 import six
 import json
 from collections import Mapping
+import copy
 
 
 class SpecMixin(object):
@@ -48,6 +49,12 @@ class SpecMixin(object):
 
         # process keyword arguments
         self.update(kw)
+
+    def __copy__(self):
+        return copy.copy(dict(self))
+
+    def __deepcopy__(self, memodict={}):
+        return copy.deepcopy(dict(self))
 
     @staticmethod
     def _serializer(value):

--- a/romanesco/specs/task.py
+++ b/romanesco/specs/task.py
@@ -176,7 +176,7 @@ class Task(AnonymousTask):
     __inputs__ = PortList()
     __outputs__ = PortList()
 
-    def __init__(self, *args, **kw):
+    def __init__(self, name, *args, **kw):
         """Initialize the spec and add private attributes."""
 
         if {'inputs', 'outputs'} & set(kw.keys()):
@@ -184,7 +184,7 @@ class Task(AnonymousTask):
                                              'read only attributes.')
 
         super(Task, self).__init__(*args, **kw)
-
+        self.name = name
         self['mode'] = kw.get("mode", "python")
 
         self.__setitem__('inputs', self.__inputs__, force=True)

--- a/romanesco/specs/task.py
+++ b/romanesco/specs/task.py
@@ -208,6 +208,4 @@ class Task(AnonymousTask):
                                              'read only attributes.')
         super(Task, self).update(other, **kw)
 
-
-
 __all__ = ('AnonymousTask', 'Task', 'ReadOnlyAttributeException', )

--- a/romanesco/specs/task.py
+++ b/romanesco/specs/task.py
@@ -179,11 +179,8 @@ class Task(AnonymousTask):
     def __init__(self, name, *args, **kw):
         """Initialize the spec and add private attributes."""
 
-        if {'inputs', 'outputs'} & set(kw.keys()):
-            raise ReadOnlyAttributeException('inputs and outputs are '
-                                             'read only attributes.')
-
         super(Task, self).__init__(*args, **kw)
+
         self.name = name
         self['mode'] = kw.get("mode", "python")
 
@@ -197,6 +194,20 @@ class Task(AnonymousTask):
             raise ReadOnlyAttributeException('%s is a read only attribute.' % key)
         else:
             super(Task, self).__setitem__(key, value)
+
+    def update(self, other=None, **kw):
+
+        """A recursive version of ``dict.update``."""
+
+        if other is not None:
+            if {'inputs', 'outputs'} & set(other):
+                raise ReadOnlyAttributeException('inputs and outputs are '
+                                                 'read only attributes.')
+        if {'inputs', 'outputs'} & set(kw):
+            raise ReadOnlyAttributeException('inputs and outputs are '
+                                             'read only attributes.')
+        super(Task, self).update(other, **kw)
+
 
 
 __all__ = ('AnonymousTask', 'Task', 'ReadOnlyAttributeException', )

--- a/romanesco/specs/utils.py
+++ b/romanesco/specs/utils.py
@@ -21,38 +21,38 @@ def spec_class_generator(class_type, spec):
 
     # Define the class
     >>> spec_class_generator("addThree", spec)
-    <class 'romanesco.specs.utils.addThree'>
+    <class 'abc.addThree'>
 
     # Set a variable to hold the class
     >>> addThree = spec_class_generator("addThree", spec)
 
     # Instantiate the class
-    >>> addThree("task_name") # doctest: +NORMALIZE_WHITESPACE
-    {"inputs": [{"format": "number", "name": "a", "type": "number"}],
-     "mode": "python",
-     "outputs": [{"format": "number", "name": "b", "type": "number"}],
-     "script": "b = a + 3"}
+    >>> dict(addThree()) # doctest: +NORMALIZE_WHITESPACE
+    {'inputs': [{"format": "number", "name": "a", "type": "number"}],
+     'script': 'b = a + 3',
+     'mode': 'python',
+     'outputs': [{"format": "number", "name": "b", "type": "number"}]}
     """
 
     # Decorator that adds 'scirpt' and 'mode' keywords from
     # the spec to the kw argument passed to the decorated function
     def add_spec_to_kw(func):
-        def wrapped_f(*args, **kwargs):
+        def wrapped_f(self, _spec=None, **kwargs):
             for k in ['script', 'mode', 'steps', 'connections']:
                 if k not in kwargs.keys():
                     try:
                         kwargs[k] = spec[k]
                     except KeyError:
                         pass
-            func(*args, **kwargs)
+            func(self, _spec, **kwargs)
         return wrapped_f
 
     # __init__ function used for the class
     @add_spec_to_kw
-    def __init__(self, name, *args, **kw):
-        specs.Task.__init__(self, name, *args, **kw)
+    def __init__(self, spec, **kw):
+        specs.Task.__init__(self, spec, **kw)
         for k, v in kw.items():
-            setattr(self, k, v)
+            self[k] = v
 
         return __init__
 

--- a/romanesco/specs/utils.py
+++ b/romanesco/specs/utils.py
@@ -1,0 +1,65 @@
+from romanesco import specs
+
+
+def spec_class_generator(class_type, spec):
+
+    """Generate a generic Task style class from a Spec style dict.
+    For example:
+
+    >>> from romanesco.specs.utils import spec_class_generator
+    >>> spec = {
+    ...             "inputs": [
+    ...                 {"name": "a",
+    ...                  "type": "number",
+    ...                  "format": "number"}],
+    ...             "outputs": [
+    ...                 {"name": "b",
+    ...                  "type": "number",
+    ...                  "format": "number"}],
+    ...             "mode": "python",
+    ...             "script": "b = a + 3"}
+
+    # Define the class
+    >>> spec_class_generator("addThree", spec)
+    <class 'romanesco.specs.utils.addThree'>
+
+    # Set a variable to hold the class
+    >>> addThree = spec_class_generator("addThree", spec)
+
+    # Instantiate the class
+    >>> addThree("task_name") # doctest: +NORMALIZE_WHITESPACE
+    {"inputs": [{"format": "number", "name": "a", "type": "number"}],
+     "mode": "python",
+     "outputs": [{"format": "number", "name": "b", "type": "number"}],
+     "script": "b = a + 3"}
+    """
+
+    # Decorator that adds 'scirpt' and 'mode' keywords from
+    # the spec to the kw argument passed to the decorated function
+    def add_spec_to_kw(func):
+        def wrapped_f(*args, **kwargs):
+            for k in ['script', 'mode', 'steps', 'connections']:
+                if k not in kwargs.keys():
+                    try:
+                        kwargs[k] = spec[k]
+                    except KeyError:
+                        pass
+            func(*args, **kwargs)
+        return wrapped_f
+
+    # __init__ function used for the class
+    @add_spec_to_kw
+    def __init__(self, name, *args, **kw):
+        specs.Task.__init__(self, name, *args, **kw)
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+        return __init__
+
+    # Define __inputs__ and __outputs__ variables on the class.
+    cls_vars = {
+        "__inputs__": specs.PortList(spec['inputs']),
+        "__outputs__": specs.PortList(spec['outputs']),
+        "__init__": __init__}
+
+    return type(class_type, (specs.Task,), cls_vars)

--- a/romanesco/specs/utils.py
+++ b/romanesco/specs/utils.py
@@ -1,5 +1,5 @@
 from romanesco import specs
-
+from collections import Hashable
 
 def spec_class_generator(class_type, spec):
 
@@ -63,3 +63,15 @@ def spec_class_generator(class_type, spec):
         "__init__": __init__}
 
     return type(class_type, (specs.Task,), cls_vars)
+
+
+def to_frozenset(item):
+    """Recursively convert 'item' to a frozenset"""
+    if isinstance(item, Hashable):
+        return item
+
+    if isinstance(item, dict):
+        return frozenset([(k, to_frozenset(v)) for k, v in item.items()])
+
+    if isinstance(item, list):
+        return frozenset([to_frozenset(v) for v in item])

--- a/romanesco/specs/utils.py
+++ b/romanesco/specs/utils.py
@@ -1,6 +1,7 @@
 from romanesco import specs
 from collections import Hashable
 
+
 def spec_class_generator(class_type, spec):
 
     """Generate a generic Task style class from a Spec style dict.

--- a/romanesco/specs/workflow.py
+++ b/romanesco/specs/workflow.py
@@ -1,0 +1,64 @@
+"""This module defines the workflow pipeline object."""
+
+# import six
+
+# import romanesco
+from romanesco.specs import PortList, ReadOnlyAttributeException
+
+from collections import MutableMapping
+import networkx as nx
+
+
+class Workflow(MutableMapping):
+
+    def __init__(self, *args, **kw):
+        self.__graph__ = nx.DiGraph()
+
+        self.__interface = {"mode", "steps", "connections",
+                            "inputs", "outputs"}
+        self.mode = "workflow"
+
+    @property
+    def steps(self):
+        return []
+
+    @property
+    def connections(self):
+        return []
+
+    @property
+    def inputs(self):
+        return PortList()
+
+    @property
+    def outputs(self):
+        return PortList()
+
+    def __getitem__(self, key):
+        if key not in self.__interface:
+            raise KeyError("Workflow keys must be one of %s" %
+                           ", ".join(self.__interface))
+
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        if key in self.__interface:
+            raise ReadOnlyAttributeException("%s should not be directly assigned")
+
+        raise KeyError("Workflow keys must be one of %s" %
+                       ", ".join(self.__interface))
+
+    def __delitem__(self, key):
+        if key in self.__interface:
+            raise ReadOnlyAttributeException("%s should not be directly removed")
+        raise KeyError(key)
+
+    def __len__(self):
+        return len(self.__interface)
+
+    def __iter__(self):
+        for key in self.__interface:
+            yield key
+
+
+__all__ = ("Workflow", )

--- a/romanesco/specs/workflow.py
+++ b/romanesco/specs/workflow.py
@@ -3,10 +3,28 @@
 # import six
 
 # import romanesco
-from romanesco.specs import PortList, ReadOnlyAttributeException
+from romanesco.specs import PortList, ReadOnlyAttributeException, Spec
 
 from collections import MutableMapping
 import networkx as nx
+
+
+class WorkflowException(Exception):
+    """Exception thrown for issues with Workflows"""
+    pass
+
+
+class DuplicateTaskException(WorkflowException):
+    """Exception thrown when adding a duplicate task"""
+    pass
+
+
+class StepSpec(Spec):
+    def __init__(self, *args, **kwargs):
+        super(StepSpec, self).__init__(*args, **kwargs)
+
+StepSpec.make_property("name", "Name of the step in the workflow")
+StepSpec.make_property("task", "Workflow task associated with this step")
 
 
 class Workflow(MutableMapping):
@@ -61,4 +79,4 @@ class Workflow(MutableMapping):
             yield key
 
 
-__all__ = ("Workflow", )
+__all__ = ("Workflow", "StepSpec", )

--- a/romanesco/specs/workflow.py
+++ b/romanesco/specs/workflow.py
@@ -36,9 +36,69 @@ class Workflow(MutableMapping):
                             "inputs", "outputs"}
         self.mode = "workflow"
 
+    ##
+    # Graph API
+    #
+
+    def _add_node(self, name, task):
+        if name in self.__graph__.nodes():
+            raise DuplicateTaskException("%s is already in Workflow!" % name)
+        self.__graph__.add_node(name, data=task)
+
+    def add_task(self, task, name=None):
+        if hasattr(task, "name"):
+            self._add_node(task.name, task)
+        elif name is not None:
+            self._add_node(name, task)
+        else:
+            raise TypeError("If task does not have a name attribute, "
+                            "name argument cannot be None.")
+        pass
+
+    def add_tasks(self, tasks):
+        for task in tasks:
+            if isinstance(task, tuple):
+                self.add_task(*task)
+            else:
+                self.add_task(task)
+
+    def _add_edge(self, t1, t2, metadata):
+        # metadata must be a dict
+        # TODO: add validation for arg0 and arg1 inputs/outputs
+        self.__graph__.add_edge(t1, t2, metadata)
+
+    def connect_tasks(self, *args, **kwargs):
+        """"""
+        # Single iterable argument - apply connect_tasks() to
+        # each element in the iterable
+        if len(args) == 1 and hasattr("__iter__", args[0]):
+            for arg in args[0]:
+                self.connect_tasks(*arg)
+
+        # Two arguments,  assume metadata is contained in kwargs
+        # _add_edge will raise an exception if this is not the case
+        elif len(args) == 2:
+            kwargs = kwargs if kwargs is not None else {}
+            self._add_edge(args[0], args[1], kwargs)
+
+        # Three arguments,  assume these are t1, t2 and a dict of edge data
+        elif len(args) == 3:
+            # Update metadata dict with key word arguments if kwargs is not None
+            if kwargs is not None:
+                args[2].update(kwargs)
+
+            self._add_edge(*args)
+        else:
+            raise TypeError("connect_tasks() takes either 3 arguments or an "
+                            "iterable of 3 argument tuples. (%s given)" % len(args))
+    ##
+    # Dict-like API
+    #
+
     @property
     def steps(self):
-        return []
+        return [StepSpec({"name": n,  "task": dict(props['data'])})
+                for n, props in self.__graph__.nodes(data=True)]
 
     @property
     def connections(self):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_docstring_test(romanesco.specs.spec)
 add_docstring_test(romanesco.specs.task)
 add_docstring_test(romanesco.specs.port)
 add_docstring_test(romanesco.specs.port_list)
+add_docstring_test(romanesco.specs.utils)
 add_docstring_test(romanesco.format)
 
 # Look for plugin.cmake in plugin dirs, include if they exist

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -256,11 +256,46 @@ class TestWorkflow(TestCase):
         }
 
     def test_spec_class_generator(self):
-
         """Instantiated classes from spec_class_generator should equal their spec"""
         for spec in [self.add, self.add_three, self.add_two, self.multiply]:
             cls = spec_class_generator("cls", spec)
             self.assertEqual(cls(), spec)
+
+    def test_empty_workflow(self):
+        """Empty Workflow objects should have certain properties"""
+        wf = specs.Workflow()
+
+        self.assertEquals(len(wf), 5)
+        self.assertEquals(set(wf.keys()), set(["mode", "steps",
+                                               "connections", "inputs",
+                                               "outputs"]))
+        self.assertEquals(wf['mode'], "workflow")
+        self.assertEquals(wf['steps'], [])
+        self.assertEquals(wf['connections'], [])
+        self.assertEquals(wf['inputs'], [])
+        self.assertEquals(wf['outputs'], [])
+
+        self.assertEquals(wf.mode, "workflow")
+        self.assertEquals(wf.steps, [])
+        self.assertEquals(wf.connections, [])
+        self.assertEquals(wf.inputs, [])
+        self.assertEquals(wf.outputs, [])
+
+        with self.assertRaises(specs.ReadOnlyAttributeException):
+            del wf['mode']
+
+        with self.assertRaises(KeyError):
+            del wf['foo']
+
+        with self.assertRaises(specs.ReadOnlyAttributeException):
+            wf['mode'] = "foo"
+
+        with self.assertRaises(KeyError):
+            wf['foo']
+
+        with self.assertRaises(KeyError):
+            wf['foo'] = "foo"
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -143,13 +143,13 @@ class TestTask(TestCase):
             __inputs__ = specs.PortList(self.inputs)
             __outputs__ = specs.PortList(self.outputs)
 
-        t = specs.Task(self.spec)
+        t = specs.Task("temp", self.spec)
         self.assertEquals(set(t.keys()), {'inputs', 'outputs', 'mode', 'script'})
 
         self.assertEquals(t['inputs'], specs.PortList())
         self.assertEquals(t['outputs'], specs.PortList())
 
-        t2 = TempTask(self.spec)
+        t2 = TempTask("temp", self.spec)
         self.assertEquals(t2['inputs'], self.inputs)
         self.assertEquals(t2['outputs'], self.outputs)
 
@@ -161,7 +161,7 @@ class TestTask(TestCase):
             __inputs__ = specs.PortList(self.inputs)
             __outputs__ = specs.PortList(self.outputs)
 
-        t = TempTask(self.spec)
+        t = TempTask("temp", self.spec)
 
         with self.assertRaises(specs.ReadOnlyAttributeException):
             t['inputs'] = specs.PortList()
@@ -176,5 +176,162 @@ class TestTask(TestCase):
             t.outputs = specs.PortList()
 
 
+class TestWorkflow(TestCase):
+
+    def setUp(self):
+        self.add_three = {
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "b",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "mode": "python",
+            "script": "b = a + 3"
+        }
+
+        self.add_two = {
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "b",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "mode": "python",
+            "script": "b = a + 2"
+        }
+
+        self.add = {
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "number",
+                    "format": "number",
+                },
+                {
+                    "name": "b",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "c",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "script": "c = a + b",
+            "mode": "python"
+        }
+
+        self.multiply = {
+            "inputs": [
+                {
+                    "name": "in1",
+                    "type": "number",
+                    "format": "number"
+                },
+                {
+                    "name": "in2",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "mode": "python",
+            "script": "out = in1 * in2"
+        }
+
+        self.workflow = {
+            "mode": "workflow",
+            "inputs": [
+                {
+                    "name": "x",
+                    "type": "number",
+                    "format": "number",
+                    "default": {"format": "number", "data": 10}
+                },
+                {
+                    "name": "y",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "outputs": [
+                {
+                    "name": "result",
+                    "type": "number",
+                    "format": "number"
+                }
+            ],
+            "steps": [
+                {
+                    "name": "af352b243109c4235d2549",
+                    "task": self.add_three,
+                },
+                {
+                    "name": "af352b243109c4235d25fb",
+                    "task": self.add_two,
+                },
+                {
+                    "name": "af352b243109c4235d25ec",
+                    "task": self.multiply,
+                }
+            ],
+            "connections": [
+                {
+                    "name": "x",
+                    "input_step": "af352b243109c4235d2549",
+                    "input": "a"
+                },
+                {
+                    "name": "y",
+                    "input_step": "af352b243109c4235d25fb",
+                    "input": "a"
+                },
+                {
+                    "output_step": "af352b243109c4235d2549",
+                    "output": "b",
+                    "input_step": "af352b243109c4235d25ec",
+                    "input": "in1"
+                },
+                {
+                    "output_step": "af352b243109c4235d25fb",
+                    "output": "b",
+                    "input_step": "af352b243109c4235d25ec",
+                    "input": "in2"
+                },
+                {
+                    "name": "result",
+                    "output_step": "af352b243109c4235d25ec",
+                    "output": "out"
+                }
+            ]
+        }
+        
+            
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -612,6 +612,32 @@ class TestWorkflow(TestCase):
 
         self.assertEquals(system, ground)
 
+    def test_workflow_with_task_classes(self):
+        wf = specs.Workflow()
+
+        AddTwo = spec_class_generator("AddTwo", self.add_two)
+        AddThree = spec_class_generator("AddThree", self.add_three)
+        Multiply = spec_class_generator("Multiply", self.multiply)
+
+        wf.add_task(AddTwo(), "a2")
+        wf.add_task(AddThree(), "a3")
+        wf.add_task(Multiply(), "m")
+
+        wf.connect_tasks("a3", "m", {"b": "in1"})
+        wf.connect_tasks("a2", "m", {"b": "in2"})
+
+        # Add default as defined in self.workflow
+        wf.set_default("a3.a", {"format": "number", "data": 10})
+
+        self.assertEquals(wf, self.workflow)
+        inputs = {"a2.a": {"format": "json", "data": "1"},
+                  "a3.a": {"format": "number", "data": 2}}
+
+        ground = romanesco.run(self.workflow, inputs=inputs)
+        system = romanesco.run(wf, inputs=inputs)
+
+        self.assertEquals(system, ground)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest import TestCase
 from romanesco import specs
+from romanesco.specs.utils import spec_class_generator
 
 
 class TestSpec(TestCase):
@@ -191,128 +192,45 @@ class TestTask(TestCase):
 class TestWorkflow(TestCase):
 
     def setUp(self):
+        self.add = {
+            "inputs": [{"name": "a", "type": "number", "format": "number"},
+                       {"name": "b", "type": "number", "format": "number"}],
+            "outputs": [{"name": "c", "type": "number", "format": "number"}],
+            "script": "c = a + b",
+            "mode": "python"}
+
         self.add_three = {
-            "inputs": [
-                {
-                    "name": "a",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "outputs": [
-                {
-                    "name": "b",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
+            "inputs": [{"name": "a", "type": "number", "format": "number"}],
+            "outputs": [{"name": "b", "type": "number", "format": "number"}],
             "mode": "python",
-            "script": "b = a + 3"
-        }
+            "script": "b = a + 3"}
 
         self.add_two = {
-            "inputs": [
-                {
-                    "name": "a",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "outputs": [
-                {
-                    "name": "b",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
+            "inputs": [{"name": "a", "type": "number", "format": "number"}],
+            "outputs": [{"name": "b", "type": "number", "format": "number"}],
             "mode": "python",
-            "script": "b = a + 2"
-        }
-
-        self.add = {
-            "inputs": [
-                {
-                    "name": "a",
-                    "type": "number",
-                    "format": "number",
-                },
-                {
-                    "name": "b",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "outputs": [
-                {
-                    "name": "c",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "script": "c = a + b",
-            "mode": "python"
-        }
+            "script": "b = a + 2"}
 
         self.multiply = {
-            "inputs": [
-                {
-                    "name": "in1",
-                    "type": "number",
-                    "format": "number"
-                },
-                {
-                    "name": "in2",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "outputs": [
-                {
-                    "name": "out",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
+            "inputs": [{"name": "in1", "type": "number", "format": "number"},
+                       {"name": "in2", "type": "number", "format": "number"}],
+            "outputs": [{"name": "out", "type": "number", "format": "number"}],
             "mode": "python",
-            "script": "out = in1 * in2"
-        }
+            "script": "out = in1 * in2"}
 
         self.workflow = {
             "mode": "workflow",
-            "inputs": [
-                {
-                    "name": "x",
-                    "type": "number",
-                    "format": "number",
-                    "default": {"format": "number", "data": 10}
-                },
-                {
-                    "name": "y",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "outputs": [
-                {
-                    "name": "result",
-                    "type": "number",
-                    "format": "number"
-                }
-            ],
-            "steps": [
-                {
-                    "name": "af352b243109c4235d2549",
-                    "task": self.add_three,
-                },
-                {
-                    "name": "af352b243109c4235d25fb",
-                    "task": self.add_two,
-                },
-                {
-                    "name": "af352b243109c4235d25ec",
-                    "task": self.multiply,
-                }
-            ],
+
+            "inputs": [{"name": "x", "type": "number", "format": "number",
+                        "default": {"format": "number", "data": 10}},
+                       {"name": "y", "type": "number", "format": "number"}],
+
+            "outputs": [{"name": "result", "type": "number", "format": "number"}],
+
+            "steps": [{"task": self.add_three, "name": "af352b243109c4235d2549"},
+                      {"task": self.add_two, "name": "af352b243109c4235d25fb"},
+                      {"task": self.multiply, "name": "af352b243109c4235d25ec"}],
+
             "connections": [
                 {
                     "name": "x",
@@ -343,6 +261,12 @@ class TestWorkflow(TestCase):
                 }
             ]
         }
+
+    def test_spec_class_generator(self):
+        for spec in [self.add, self.add_three, self.add_two,
+                     self.multiply, self.workflow]:
+            cls = spec_class_generator("cls", spec)
+            self.assertEqual(cls("test"), spec)
 
 
 if __name__ == '__main__':

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -1,8 +1,9 @@
 """Tests for core spec objects."""
 import unittest
+import collections
 from unittest import TestCase
 from romanesco import specs
-from romanesco.specs.utils import spec_class_generator
+from romanesco.specs.utils import spec_class_generator, to_frozenset
 
 
 class TestSpec(TestCase):
@@ -295,6 +296,47 @@ class TestWorkflow(TestCase):
 
         with self.assertRaises(KeyError):
             wf['foo'] = "foo"
+
+    def test_workflow_add_task_dict(self):
+        """Adding task dicts should show up in Workflow.steps"""
+        wf = specs.Workflow()
+
+        wf.add_task(self.add, "add")
+        task_list = [{"name": "add", "task": self.add}]
+        # Steps should be equal to a list of dicts
+        self.assertEquals(wf['steps'], task_list)
+        self.assertEquals(wf.steps, task_list)
+
+        # Steps should be equal to a list of Spec() dicts
+        self.assertEquals(wf['steps'], [specs.Spec(t) for t in task_list])
+        self.assertEquals(wf.steps, [specs.Spec(t) for t in task_list])
+
+        # Steps should be equal to a list of StepSpec() dicts
+        self.assertEquals(wf['steps'], [specs.StepSpec(t) for t in task_list])
+        self.assertEquals(wf.steps, [specs.StepSpec(t) for t in task_list])
+
+        # No duplicate nodes
+        with self.assertRaises(specs.DuplicateTaskException):
+            wf.add_task(self.add, "add")
+
+        # Test with multiple tasks of the same type (different name)
+        wf.add_task(self.add, "add2")
+        task_list += [{"name": "add2", "task": self.add}]
+
+        self.assertEquals(to_frozenset(wf['steps']), to_frozenset(task_list))
+        self.assertEquals(to_frozenset(wf.steps), to_frozenset(task_list))
+
+        self.assertEquals(to_frozenset(wf['steps']),
+                          to_frozenset([specs.Spec(t) for t in task_list]))
+        self.assertEquals(to_frozenset(wf.steps),
+                          to_frozenset([specs.Spec(t) for t in task_list]))
+
+        # Steps should be equal to a list of StepSpec() dicts
+        self.assertEquals(to_frozenset(wf['steps']),
+                          to_frozenset([specs.StepSpec(t) for t in task_list]))
+        self.assertEquals(to_frozenset(wf.steps),
+                          to_frozenset([specs.StepSpec(t) for t in task_list]))
+
 
 
 if __name__ == '__main__':

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -87,3 +87,30 @@ class TestTask(TestCase):
 
         with self.assertRaises(ValueError):
             t.set_input(z=0)
+
+    def test_task_inputs_outputs_equality(self):
+        """Test input and output equality through specs, task __getitem__
+        interface and task __getattr__ interface."""
+        inputs = sorted([
+            {'name': 'a', 'type': 'string', 'format': 'text'},
+            {'name': 'b', 'type': 'number', 'format': 'number'},
+            {'name': 'c', 'type': 'number', 'format': 'number'},
+        ])
+        outputs = sorted([
+            {'name': 'd', 'type': 'string', 'format': 'text'}
+        ])
+
+        spec = {
+            'inputs': inputs,
+            'outputs': outputs,
+            'script': "d = a + ':' + str(b + c)"}
+
+        t = specs.Task(spec)
+
+        self.assertEquals(sorted(spec['inputs']), inputs)
+        self.assertEqual(sorted(spec['outputs']), outputs)
+
+        self.assertEquals(sorted(t['inputs']), inputs)
+        self.assertEqual(sorted(t['outputs']), outputs)
+
+        self.assertEquals(sorted(t.inputs), inputs)

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -161,6 +161,18 @@ class TestTask(TestCase):
             __inputs__ = specs.PortList(self.inputs)
             __outputs__ = specs.PortList(self.outputs)
 
+        # Test if passed in in spec dict
+        with self.assertRaises(specs.ReadOnlyAttributeException):
+            spec = self.spec.copy()
+            spec['inputs'] = specs.PortList()
+            TempTask("temp", spec)
+
+        with self.assertRaises(specs.ReadOnlyAttributeException):
+            spec = self.spec.copy()
+            spec['outputs'] = specs.PortList()
+            TempTask("temp", spec)
+
+        # Test if assigned after instatiation
         t = TempTask("temp", self.spec)
 
         with self.assertRaises(specs.ReadOnlyAttributeException):
@@ -331,7 +343,7 @@ class TestWorkflow(TestCase):
                 }
             ]
         }
-        
-            
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This PR implements a pythonic interface to romanesco workflows:

Given the following ```workflow```:

```python
workflow = {
    'mode': 'workflow',
    'inputs': [{
        'default': {
            'data': 10,
            'format': 'number'
        },
        'format': 'number',
        'name': 'a3.a',
        'type': 'number'
    }, {
        'format': 'number',
        'name': 'a2.a',
        'type': 'number'
    }],
    'outputs': [{
        'format': 'number',
        'name': 'out',
        'type': 'number'
    }],
    'steps': [{
        'name': 'a3',
        'task': {
            'inputs': [{
                'format': 'number',
                'name': 'a',
                'type': 'number'
            }],
            'mode': 'python',
            'outputs': [{
                'format': 'number',
                'name': 'b',
                'type': 'number'
            }],
            'script': 'b = a + 3'
        }
    }, {
        'name': 'a2',
        'task': {
            'inputs': [{
                'format': 'number',
                'name': 'a',
                'type': 'number'
            }],
            'mode': 'python',
            'outputs': [{
                'format': 'number',
                'name': 'b',
                'type': 'number'
            }],
            'script': 'b = a + 2'
        }
    }, {
        'name': 'm',
        'task': {
            'inputs': [{
                'format': 'number',
                'name': 'in1',
                'type': 'number'
            }, {
                'format': 'number',
                'name': 'in2',
                'type': 'number'
            }],
            'mode': 'python',
            'outputs': [{
                'format': 'number',
                'name': 'out',
                'type': 'number'
            }],
            'script': 'out = in1 * in2'
        }
    }],
   'connections': [{
        'input': 'a',
        'input_step': 'a3',
        'name': 'a3.a'
    }, {
        'input': 'a',
        'input_step': 'a2',
        'name': 'a2.a'
    }, {
        'input': 'in1',
        'input_step': 'm',
        'output': 'b',
        'output_step': 'a3'
    }, {
        'input': 'in2',
        'input_step': 'm',
        'output': 'b',
        'output_step': 'a2'
    }, {
        'name': 'out',
        'output': 'out',
        'output_step': 'm'
    }],
}

```

This may now be written with the following syntax:

```python

wf = specs.Workflow()

add_two = {
    "inputs": [{"name": "a", "type": "number", "format": "number"}],
    "outputs": [{"name": "b", "type": "number", "format": "number"}],
    "mode": "python",
    "script": "b = a + 2"}

add_three = {
    "inputs": [{"name": "a", "type": "number", "format": "number"}],
    "outputs": [{"name": "b", "type": "number", "format": "number"}],
    "mode": "python",
    "script": "b = a + 3"}

multiply = {
    "inputs": [{"name": "in1", "type": "number", "format": "number"},
               {"name": "in2", "type": "number", "format": "number"}],
    "outputs": [{"name": "out", "type": "number", "format": "number"}],
    "mode": "python",
            "script": "out = in1 * in2"}

wf.add_task(add_two, "a2")
wf.add_task(add_three, "a3")
wf.add_task(multiply, "m")

wf.connect_tasks("a3", "m", {"b": "in1"})
wf.connect_tasks("a2", "m", {"b": "in2"})

# Add default as defined in self.workflow
wf.set_default("a3.a", {"format": "number", "data": 10})
```

If the ```add_two```, ```add_three```, and ```multiply``` spec definitions are in files one may use ```spec_class_generator``` to load these as generic,  dynamic classes inheriting from specs.Task

```python
with open("/path/to/add_two.json", "r") as fh:
    AddTwo = spec_class_generator("AddTwo", fh.read())

with open("/path/to/add_three.json", "r") as fh:
    AddThree = spec_class_generator("AddThree", fh.read())

with open("/path/to/add_three.json", "r") as fh:
    Multiply = spec_class_generator("Multiply", fh.read())

wf = specs.Workflow()

wf.add_task(AddTwo(), "a2")
wf.add_task(AddThree(), "a3")
wf.add_task(Multiply(), "m")

wf.connect_tasks("a3", "m", {"b": "in1"})
wf.connect_tasks("a2", "m", {"b": "in2"})

# Add default as defined in self.workflow
wf.set_default("a3.a", {"format": "number", "data": 10})

```

These classes may also be defined statically as follows:

```python
class AddTwo(specs.Task):
    __inputs__ = specs.PortList([
        {"name": "a", "type": "number", "format": "number"}
    ])
    __outputs__ = specs.PortList([
        {"name": "b", "type": "number", "format": "number"}
    ])
    
    def __init__(self, spec=None, **kw):
        super(AddTwo, self).__init__(spec, **kw)
        self.mode = "python"
        self.script = "b = a + 2"
        
class AddThree(specs.Task):
    __inputs__ = specs.PortList([
        {"name": "a", "type": "number", "format": "number"}
    ])
    __outputs__ = specs.PortList([
        {"name": "b", "type": "number", "format": "number"}
    ])
    
    def __init__(self, spec=None, **kw):
        super(AddThree, self).__init__(spec, **kw)
        self.mode = "python"
        self.script = "b = a + 3"
        
class Multiply(specs.Task):
    __inputs__ = specs.PortList([
        {"name": "in1", "type": "number", "format": "number"},
        {"name": "in2", "type": "number", "format": "number"}
    ])
    __outputs__ = specs.PortList([
        {"name": "out", "type": "number", "format": "number"}
    ])
    
    def __init__(self, spec=None, **kw):
        super(Multiply, self).__init__(spec, **kw)
        self.mode = "python"
        self.script = "out = in1 * in2"
        
wf = specs.Workflow()

wf.add_task(AddTwo(), "a2")
wf.add_task(AddThree(), "a3")
wf.add_task(Multiply(), "m")

wf.connect_tasks("a3", "m", {"b": "in1"})
wf.connect_tasks("a2", "m", {"b": "in2"})

# Add default as defined in self.workflow
wf.set_default("a3.a", {"format": "number", "data": 10})
```

Finally,  in all three cases the following assertions are True

```python

TestCase.assertEquals(wf, workflow)

inputs = {"a2.a": {"format": "json", "data": "1"},
          "a3.a": {"format": "number", "data": 2}}

ground = romanesco.run(workflow, inputs=inputs)
system = romanesco.run(wf, inputs=inputs)

TestCase.assertEquals(system, ground)
```