### PR TITLE
Allow includes of JS/CSS on read the docs

### DIFF
--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -1,4 +1,4 @@
-{% extends "!layout.html" %}
+{%- extends "layout.html" %}
 
 {% block extrahead %}
   {% if pagename == 'examples' %}
@@ -6,4 +6,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
     <script src="{{ pathto('_static/facebook-example.js', 1) }}"></script>
   {% endif %}
+{% endblock %}
+
+
+{% block body %}
+  {{ body }}
 {% endblock %}


### PR DESCRIPTION
I can't assure this will work (aside from it working on my local machine). Is there a way to test this branch on RTD?

Though, extending ```layout.html``` is currently broken it seems. This is an [open issue](https://github.com/rtfd/readthedocs.org/issues/152) on RTD. 

This, unfortunately means that occurrences in [tangelo](https://github.com/Kitware/tangelo/blob/develop/docs/templates/layout.html) are probably not working either.