### PR TITLE
Fix NetworkX Keyword Arguments

### DIFF
--- a/romanesco/format/__init__.py
+++ b/romanesco/format/__init__.py
@@ -225,7 +225,7 @@ def import_converters(search_paths):
 
             conv_graph.add_edge(Validator(in_type, in_format),
                                 Validator(in_type, out_format),
-                                analysis)
+                                attr_dict=analysis)
 
     os.chdir(prevdir)
 

--- a/romanesco/format/graph/clique_json_to_networkx.py
+++ b/romanesco/format/graph/clique_json_to_networkx.py
@@ -21,4 +21,4 @@ for node in nodes:
 for edge in edges:
     output.add_edge(edge['source']['$oid'],
                     edge['target']['$oid'],
-                    edge['data'] if 'data' in edge else {})
+                    attr_dict=edge['data'] if 'data' in edge else {})

--- a/romanesco/plugins/vtk/converters/graph/vtkgraph_to_networkx.py
+++ b/romanesco/plugins/vtk/converters/graph/vtkgraph_to_networkx.py
@@ -13,4 +13,4 @@ for node in range(input.GetNumberOfVertices()):
 for edge in range(input.GetNumberOfEdges()):
     output.add_edge(input.GetSourceVertex(edge),
                     input.GetTargetVertex(edge),
-                    vtkrow_to_dict(input.GetEdgeData(), edge))
+                    attr_dict=vtkrow_to_dict(input.GetEdgeData(), edge))


### PR DESCRIPTION
This isn't strictly needed in Graph/DiGraph but it should be specified in MultiGraph/MultiDiGraphs as Roni and I discovered. 

Adding it to all instances of ```add_edge```... I suppose explicit *is* better than implicit.