### PR TITLE
Add is_valid function to Validator class

### DIFF
--- a/romanesco/format/__init__.py
+++ b/romanesco/format/__init__.py
@@ -26,6 +26,22 @@ class Validator(namedtuple('Validator', ['type', 'format'])):
         The validator format, like ``text``.
     """
 
+    def is_valid(self):
+        """Return whether the type/format combination is valid.
+
+        If rformat is None is_valid just checks for the presense of any
+        valid type/format has that type.
+
+        :param rtype" ``string``
+        :param rformat" ``string`` optional
+        :returns: ``True`` if ``rtype`` and ``rformat`` are a valid, loaded
+        romanesco type/format pair.
+        """
+        if self.format is None:
+            return self.type in set(v.type for v in conv_graph.nodes())
+
+        return self in conv_graph.nodes()
+
 
 def csv_to_rows(input):
 
@@ -91,7 +107,7 @@ def converter_path(source, target):
     try:
         get_validator_analysis(source)
         get_validator_analysis(target)
-    except:
+    except Exception:
         raise NetworkXNoPath
 
     # We sort and pick the first of the shortest paths just to produce a stable

--- a/romanesco/specs/port.py
+++ b/romanesco/specs/port.py
@@ -3,7 +3,7 @@
 import six
 
 from romanesco import io, convert, isvalid
-from romanesco.format import has_converter, Validator
+from romanesco.format import Validator
 from .spec import Spec
 
 
@@ -114,12 +114,13 @@ class Port(Spec):
 
     def __check_types(self, key=None, oldvalue=None, newvalue=None, **kw):
         """Ensure the data format given is known."""
-        if key in ('type', None) and not has_converter(Validator(self['type'], None)):
-            raise ValueError(
-                'Unknown type "%s"' % (self['type'],)
-            )
-        elif key in ('format', None) and not has_converter(Validator(self['type'],
-                                                                     self['format'])):
+        if key in ('type', None) and not Validator(self['type'],
+                                                   None).is_valid():
+            raise ValueError('Unknown type "%s"' % (self['type'],))
+
+        elif key in ('format',
+                     None) and not Validator(self['type'],
+                                             self['format']).is_valid():
             raise ValueError(
                 'Unknown format "%s.%s"' % (self['type'], self['format'])
             )

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -35,6 +35,22 @@ class TestFormat(unittest.TestCase):
         self.assertEquals(len(converter_path(self.stringTextValidator,
                                              Validator('string', 'json'))), 1)
 
+    def test_is_valid(self):
+        self.assertEquals(Validator('string', None).is_valid(), True)
+
+        self.assertEquals(Validator('string', 'json').is_valid(), True)
+
+        self.assertEquals(Validator("invalid_type", None).is_valid(), False)
+
+        self.assertEquals(Validator("invalid_type",
+                                    "invalid_format").is_valid(), False)
+
+        self.assertEquals(Validator("string",
+                                    "invalid_format").is_valid(), False)
+
+        self.assertEquals(Validator("invalid_type",
+                                    "json").is_valid(), False)
+
     def test_has_converter(self):
         # There are converters from string type
         self.assertTrue(has_converter(Validator('string', None)))


### PR DESCRIPTION
This implements an is_valid() function on the Validator class providing an API for validating Port specs.  

Previously ```has_converter``` was being used to validate type/format named tuples.  Unfortunately if a type/format exists but does not have a converter than ```has_converter``` will return False incorrectly. For example ```{type="netcdf",  format="dataset"}``` is a valid data type,  but has no converter (There is only a ```binary``` to ```dataset``` converter) exists. 

This makes validation of port metadata a separate distinct function.