### PR TITLE
Girder io update file

### DIFF
--- a/romanesco/plugins/girder_io/__init__.py
+++ b/romanesco/plugins/girder_io/__init__.py
@@ -3,6 +3,7 @@ import six
 import os
 import romanesco
 
+
 def _init_client(spec, require_token=False):
     if 'host' not in spec:
         raise Exception('Host key required for girder fetch mode')
@@ -79,7 +80,7 @@ def push_handler(data, spec, **kwargs):
             raise Exception('Must pass a file name for girder item outputs.')
 
         client.uploadFile(spec['parent_id'], data,
-                          spec.get('file_name', spec['name']), size)
+                          spec.get('file_name', spec.get('name')), size)
     else:
         raise Exception('Invalid parent type: ' + parent_type)
 

--- a/romanesco/plugins/girder_io/requirements.txt
+++ b/romanesco/plugins/girder_io/requirements.txt
@@ -1,1 +1,1 @@
-girder-client==1.0.1
+girder-client==1.1.0


### PR DESCRIPTION
This alters girder_io's behavior to use the ```uploadFile``` function instead of the ```uploadFileToItem``` function.  The primary difference is ```uploadFile``` can take a ```ByteIO``` object while ```uploadFileToItem``` expects a path to a file on disk. This allows the output of a romanesco task/workflow to be directly uploaded to the server,  rather than written to disk then re-read and uploaded.   This means the 'data' field of the output data-spec should be the actual data and not a path which is a breaking change. 