### PR TITLE
Fix sphinx docstring warnings and add spec docs

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -242,3 +242,9 @@ Formats
 
 .. automodule:: romanesco.format
    :members:
+
+Pythonic task API
+-----------------
+
+.. automodule:: romanesco.specs
+   :members:

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -102,6 +102,7 @@ new item with the same name as the file), or into an existing item.
         (, "token": <girder token used for authentication>)
         (, "parent_type": <"folder" or "item", default is "folder">)
     }
+
 R
 -
 

--- a/docs/types-and-formats.rst
+++ b/docs/types-and-formats.rst
@@ -91,8 +91,7 @@ A list of rows with ordered, named column attributes. Formats:
     ``"objectlist"`` format. This is the format of MongoDB collections.
 
 :``"csv"``: A string containing the contents of a comma-separated CSV file.
-    Column headers will be reasonably detected if present, otherwise
-    columns will be named ``"Column 1"``, ``Column 2"``, etc.
+    The first line of the file is assumed to contain column headers.
 
 :``"tsv"``: A string containing the contents of a tab-separated TSV file.
     Column headers are detected the same as for the ``"csv"`` format.

--- a/docs/types-and-formats.rst
+++ b/docs/types-and-formats.rst
@@ -93,7 +93,6 @@ A list of rows with ordered, named column attributes. Formats:
 :``"csv"``: A string containing the contents of a comma-separated CSV file.
     Column headers will be reasonably detected if present, otherwise
     columns will be named ``"Column 1"``, ``Column 2"``, etc.
-    See `has_header`_ for details on header detection.
 
 :``"tsv"``: A string containing the contents of a tab-separated TSV file.
     Column headers are detected the same as for the ``"csv"`` format.

--- a/romanesco/specs/port.py
+++ b/romanesco/specs/port.py
@@ -52,11 +52,13 @@ class Port(Spec):
     >>> port = Port(spec)
 
     The port object is serialized as a json object
+
     >>> import json
     >>> json.loads(str(port)) == spec
     True
 
     It has several properties derived from the spec
+
     >>> port.name == spec['name']
     True
     >>> port.type == spec['type']
@@ -65,12 +67,14 @@ class Port(Spec):
     True
 
     It also supports auto converting formats and validation by default
+
     >>> port.auto_convert
     True
     >>> port.auto_validate
     True
 
     Spec properties are automatically validated when setting them
+
     >>> port = Port()
     Traceback (most recent call last):
         ...
@@ -83,6 +87,7 @@ class Port(Spec):
     ValueError: Unknown format "python.invalid"
 
     Checking the ``type`` is deferred to allow incremental updating
+
     >>> port['type'] = 'image'
     >>> port.json()
     Traceback (most recent call last):

--- a/romanesco/specs/port_list.py
+++ b/romanesco/specs/port_list.py
@@ -17,10 +17,12 @@ class PortList(SpecMixin, list):
     '[]'
 
     Ports can be added as instances or dictionaries
+
     >>> l.append(Port(name='z'))
     >>> l.append({'name': 'a', 'type': 'image', 'format': 'png'})
 
     Normal list methods are supported
+
     >>> l[1] = '{"name": "b"}'
     >>> l.insert(1, {"name": "c"})
     >>> del l[1]
@@ -28,21 +30,25 @@ class PortList(SpecMixin, list):
     '[{"name": "z"}, {"name": "b"}]'
 
     Port lists have keys and values methods like dicts
+
     >>> l.keys()[0]
     'z'
 
     Ports can be referenced by either their index in the list or by name
+
     >>> l[0] is l['z']
     True
     >>> 'z' in l
     True
 
     Ports can be modified after they are added
+
     >>> l[0].name = 'y'
     >>> l.json()
     '[{"name": "y"}, {"name": "b"}]'
 
     Several validation checks are performed
+
     >>> l[0].name = 'b'
     Traceback (most recent call last):
         ...

--- a/romanesco/specs/spec.py
+++ b/romanesco/specs/spec.py
@@ -199,27 +199,32 @@ class Spec(SpecMixin, dict):
     Defines core utility methods that all spec objects have in common.
 
     Supports dict-like initialization.
+
     >>> a = Spec({'a': 1, 'b': {'c': [1, 2, None]}})
     >>> b = Spec(a=1, b={'c': [1, 2, None]})
     >>> a == b
     True
 
     Also supports initialization from json.
+
     >>> c = Spec('{"a": 1, "b": {"c": [1, 2, null]}}')
     >>> a == c
     True
 
     Multiple initialization method can be used together, which will be inserted
     in order.
+
     >>> Spec('{"a": 0}', {'a': 1}, a=2)
     {"a": 2}
 
     Updating merging specs is always done recursively.
+
     >>> Spec('{"a": {"b": 0}}', a={'c': 1})
     {"a": {"b": 0, "c": 1}}
 
     Conflicts are resolved by taking the value with highest priority (i.e.
     the once provided next in the constructor.)
+
     >>> Spec('{"a": {"b": 0}}', {"a": []})
     {"a": []}
     >>> Spec('{"a": {"b": 0}}', {"a": []}, a={"c": 1})
@@ -228,15 +233,18 @@ class Spec(SpecMixin, dict):
     {"a": {"b": 0, "c": 1}}
 
     Serialization is performed as json
+
     >>> str(a)
     '{"a": 1, "b": {"c": [1, 2, null]}}'
 
     Strings are assumed to be utf-8 encoded.
+
     >>> str(Spec({u"for\u00eat": u"\ud83c\udf33 \ud83c\udf32 \ud83c\udf34"}))
     '{"for\\u00eat": "\\ud83c\\udf33 \\ud83c\\udf32 \\ud83c\\udf34"}'
 
     Methods that mutate the state of the Spec will test if the new state is
     valid, restoring the original state before raising an exception.
+
     >>> s = Spec({'a': 0})
     >>> try:
     ...     s['a'] = object
@@ -248,6 +256,7 @@ class Spec(SpecMixin, dict):
     {"a": 0}
 
     Spec constructors are idempotent
+
     >>> Spec(a='a') == Spec(Spec(a='a'))
     True
     """


### PR DESCRIPTION
The api docs could probably be better organized with a bit of an introduction for each component, but at least includes them.