### PR TITLE
Add validator endpoint to REST API

### DIFF
--- a/romanesco/__main__.py
+++ b/romanesco/__main__.py
@@ -1,4 +1,5 @@
 import romanesco
+from romanesco.format import conv_graph
 
 from .utils import JobManager
 from celery import Celery
@@ -28,6 +29,20 @@ def main():
     @app.task
     def convert(*pargs, **kwargs):
         return romanesco.convert(*pargs, **kwargs)
+
+    @app.task
+    def validators(*pargs, **kwargs):
+        _type, _format = pargs
+        nodes = []
+
+        for (node, data) in conv_graph.nodes(data=True):
+            if ((_type is None) or (_type == node.type)) and \
+               ((_format is None) or (_format == node.format)):
+                nodes.append({'type': node.type,
+                              'format': node.format,
+                              'validator': data})
+
+        return nodes
 
     app.worker_main()
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -364,7 +364,7 @@ def load(info):
         (':itemId', 'romanesco', ':jobId'),
         romanescoStopRun)
 
-    info['apiRoot'].validator = Validator(getCeleryApp())
+    info['apiRoot'].romanesco_validator = Validator(getCeleryApp())
 
     events.bind('jobs.schedule', 'romanesco', schedule)
     events.bind('model.setting.validate', 'romanesco', validateSettings)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -16,6 +16,7 @@ from girder.api.describe import Description
 from girder.models.model_base import AccessException, ValidationException
 from girder.utility.model_importer import ModelImporter
 from girder.plugins.jobs.constants import JobStatus
+from girder.plugins.romanesco.validator import Validator
 
 # If you desire authorization to run analyses (strongly encouraged), make sure
 # to specify so in the plugin settings page. By default, authorization control
@@ -362,6 +363,8 @@ def load(info):
         'DELETE',
         (':itemId', 'romanesco', ':jobId'),
         romanescoStopRun)
+
+    info['apiRoot'].validator = Validator(getCeleryApp())
 
     events.bind('jobs.schedule', 'romanesco', schedule)
     events.bind('model.setting.validate', 'romanesco', validateSettings)

--- a/server/validator.py
+++ b/server/validator.py
@@ -4,7 +4,7 @@ from girder.api.describe import Description
 
 class Validator(Resource):
     def __init__(self, celeryApp):
-        self.resourceName = 'validator'
+        self.resourceName = 'romanesco_validator'
         self.route('GET', (), self.find)
         self.celeryApp = celeryApp
 

--- a/server/validator.py
+++ b/server/validator.py
@@ -2,6 +2,7 @@ from girder.api import access
 from girder.api.rest import Resource
 from girder.api.describe import Description
 
+
 class Validator(Resource):
     def __init__(self, celeryApp):
         self.resourceName = 'romanesco_validator'

--- a/server/validator.py
+++ b/server/validator.py
@@ -1,0 +1,20 @@
+from girder.api import access
+from girder.api.rest import Resource
+from girder.api.describe import Description
+
+class Validator(Resource):
+    def __init__(self, celeryApp):
+        self.resourceName = 'validator'
+        self.route('GET', (), self.find)
+        self.celeryApp = celeryApp
+
+    @access.public
+    def find(self, params):
+        return self.celeryApp.send_task('romanesco.validators', [
+            params.get('type', None),
+            params.get('format', None)]).get()
+    find.description = (
+        Description('List or search for validators.')
+        .param('type', 'Find validators with this type.', required=False)
+        .param('format', 'Find validators with this format.', required=False)
+    )


### PR DESCRIPTION
This adds the capability to query Romanesco for the validators it has loaded, optionally filtering by the type and format.