### PR TITLE
Update celery, kombu for compatibility with pymongo 3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ Pillow==2.4.0
 amqp==1.4.5
 anyjson==0.3.3
 billiard==3.3.0.17
-celery==3.1.11
-kombu==3.0.15
+celery==3.1.19
+kombu==3.0.29
 pymongo==3.0.3
 pytz==2014.2
 requests==2.6.0


### PR DESCRIPTION
This fixes the following error seen in girder:

      ...
      File "/home/msmolens/dev/girder/plugins/romanesco/server/__init__.py", line 64, in schedule
	'romanesco.run', job['args'], job['kwargs'])
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/celery/app/base.py", line 351, in send_task
	reply_to=reply_to or self.oid, **options
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/celery/app/amqp.py", line 305, in publish_task
	**kwargs
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/messaging.py", line 168, in publish
	routing_key, mandatory, immediate, exchange, declare)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/connection.py", line 440, in _ensured
	return fun(*args, **kwargs)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/messaging.py", line 180, in _publish
	[maybe_declare(entity) for entity in declare]
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/messaging.py", line 111, in maybe_declare
	return maybe_declare(entity, self.channel, retry, **retry_policy)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/common.py", line 99, in maybe_declare
	return _maybe_declare(entity)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/common.py", line 110, in _maybe_declare
	entity.declare()
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/entity.py", line 505, in declare
	self.queue_declare(nowait, passive=False)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/entity.py", line 531, in queue_declare
	nowait=nowait)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/transport/virtual/__init__.py", line 447, in queue_declare
	return queue_declare_ok_t(queue, self._size(queue), 0)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/transport/mongodb.py", line 115, in _size
	return self.get_messages().find({'queue': queue}).count()
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/transport/mongodb.py", line 262, in get_messages
	return self.client[DEFAULT_MESSAGES_COLLECTION]
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/transport/mongodb.py", line 256, in client
	self._open()
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/kombu/transport/mongodb.py", line 179, in _open
	use_greenlets=_detect_environment() != 'default',
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/pymongo/mongo_client.py", line 322, in __init__
	username, password, dbase, opts)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/pymongo/client_options.py", line 108, in __init__
	options = dict([validate(opt, val) for opt, val in iteritems(options)])
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/pymongo/common.py", line 452, in validate
	value = validator(option, value)
      File "/home/msmolens/dev/python/girder.git/local/lib/python2.7/site-packages/pymongo/common.py", line 100, in raise_config_error
	raise ConfigurationError("Unknown option %s" % (key,))
    ConfigurationError: Unknown option auto_start_request