### PR TITLE
Fix png validator

### DIFF
--- a/romanesco/format/image/validate_png.json
+++ b/romanesco/format/image/validate_png.json
@@ -1,6 +1,6 @@
 {
     "inputs": [{"name": "input", "type": "image", "format": "png"}],
     "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
-    "script": "output = isinstance(input, str)",
+    "script": "output = isinstance(input, (str,unicode))",
     "mode": "python"
 }

--- a/romanesco/format/image/validate_png_base64.json
+++ b/romanesco/format/image/validate_png_base64.json
@@ -1,6 +1,6 @@
 {
     "inputs": [{"name": "input", "type": "image", "format": "png.base64"}],
     "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
-    "script": "output = isinstance(input, str)",
+    "script": "output = isinstance(input, (str,unicode))",
     "mode": "python"
 }


### PR DESCRIPTION
Fixed validator on PNG and PNG-base64 to include unicode option so romanesco analyses generating png images can be executed through the Flow editor.  

NOTE:  The PNG-base64 validator may still need an "extensions attribute" to match the PNG one.  I didn't do this because I am uncertain about how the extensions attribute is being used. 