### PR TITLE
Allow girder IO mode to use memory targets

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -85,6 +85,14 @@ Girder IO
         (, "resource_type": <"file", "item", or "folder", default is "file">)
     }
 
+.. note :: For historical reasons, task inputs that do not specify a ``target`` field
+   and are bound to a Girder input will default to having the data downloaded to
+   a file (i.e. ``target="filepath"`` behavior). This is different from the normal
+   default behavior for other IO modes, which is to download the data to an
+   object in memory. For this reason, it is suggested that if your task input is going
+   to support Girder IO mode, that you specify the ``target`` field explicitly
+   on it rather than using the default.
+
 The output mode also assumes data of format ``string/text`` that is a path to a file
 in the filesystem. That file will then be uploaded under an existing folder (under a
 new item with the same name as the file), or into an existing item.

--- a/romanesco/__init__.py
+++ b/romanesco/__init__.py
@@ -288,7 +288,7 @@ def run(task, inputs=None, outputs=None, auto_convert=True, validate=True,
             if auto_convert:
                 outputs[name] = romanesco.convert(
                     task_output["type"], script_output, d,
-                    task_output=task_output, **kwargs)
+                    **dict({'task_output': task_output}, **kwargs))
             elif d["format"] == task_output["format"]:
                 data = d["script_data"]
                 if d.get("mode"):

--- a/romanesco/__init__.py
+++ b/romanesco/__init__.py
@@ -147,7 +147,7 @@ def convert(type, input, output, **kwargs):
         data = data_descriptor["data"]
 
     if "mode" in output:
-        romanesco.io.push(data, output)
+        romanesco.io.push(data, output, **kwargs)
     else:
         output["data"] = data
     return output
@@ -231,7 +231,8 @@ def run(task, inputs=None, outputs=None, auto_convert=True, validate=True,
             task_input = task_inputs[name]
 
             # Validate the input
-            if validate and not romanesco.isvalid(task_input["type"], d, **kwargs):
+            if validate and not romanesco.isvalid(
+                    task_input["type"], d, **dict({'task_input': task_input}, **kwargs)):
                 raise Exception(
                     "Input %s (Python type %s) is not in the expected type (%s) "
                     "and format (%s)." % (
@@ -240,14 +241,15 @@ def run(task, inputs=None, outputs=None, auto_convert=True, validate=True,
 
             # Convert data
             if auto_convert:
-                converted = romanesco.convert(task_input["type"], d,
-                                              {"format": task_input["format"]}, **kwargs)
+                converted = romanesco.convert(
+                    task_input["type"], d, {"format": task_input["format"]},
+                    **dict({'task_input': task_input}, **kwargs))
                 d["script_data"] = converted["data"]
             elif (d.get("format", task_input.get("format")) ==
                   task_input.get("format")):
                 if "data" not in d:
                     d["data"] = romanesco.io.fetch(
-                        d, task_input=task_input, **kwargs)
+                        d, **dict({'task_input': task_input}, **kwargs))
                 d["script_data"] = d["data"]
             else:
                 raise Exception("Expected exact format match but '%s != %s'." % (
@@ -273,8 +275,9 @@ def run(task, inputs=None, outputs=None, auto_convert=True, validate=True,
                              "format": task_output["format"]}
 
             # Validate the output
-            if validate and not romanesco.isvalid(task_output["type"],
-                                                  script_output, **kwargs):
+            if validate and not romanesco.isvalid(
+                    task_output["type"], script_output,
+                    **dict({'task_output': task_output}, **kwargs)):
                 raise Exception(
                     "Output %s (%s) is not in the expected type (%s) and format "
                     " (%s)." % (
@@ -284,11 +287,13 @@ def run(task, inputs=None, outputs=None, auto_convert=True, validate=True,
 
             if auto_convert:
                 outputs[name] = romanesco.convert(
-                    task_output["type"], script_output, d, **kwargs)
+                    task_output["type"], script_output, d,
+                    task_output=task_output, **kwargs)
             elif d["format"] == task_output["format"]:
                 data = d["script_data"]
                 if d.get("mode"):
-                    romanesco.io.push(data, d, task_output=task_output, **kwargs)
+                    romanesco.io.push(data, d,
+                                      **dict({'task_output': task_output}, **kwargs))
                 else:
                     d["data"] = data
             else:

--- a/romanesco/plugins/girder_io/__init__.py
+++ b/romanesco/plugins/girder_io/__init__.py
@@ -59,10 +59,8 @@ def fetch_handler(spec, **kwargs):
 
 def push_handler(data, spec, **kwargs):
     parent_type = spec.get('parent_type', 'folder')
-    name = spec.get('name', os.path.basename(data))
     taskOutput = kwargs.get('task_output', {})
     target = taskOutput.get('target', 'filepath')
-    description = spec.get('description')
 
     if 'parent_id' not in spec:
         raise Exception('Must pass parent ID for girder outputs.')
@@ -72,8 +70,9 @@ def push_handler(data, spec, **kwargs):
     if target == 'memory':
         fd = StringIO(data)
         client.uploadFile(parentId=spec['parent_id'], stream=fd, size=len(data),
-                          parentType=parent_type, name=name)
+                          parentType=parent_type, name=spec['name'])
     elif target == 'filepath':
+        name = spec.get('name', os.path.basename(data))
         size = os.path.getsize(data)
         with open(data, 'rb') as fd:
             client.uploadFile(parentId=spec['parent_id'], stream=fd, size=size,

--- a/romanesco/plugins/girder_io/__init__.py
+++ b/romanesco/plugins/girder_io/__init__.py
@@ -2,6 +2,8 @@ import girder_client
 import os
 import romanesco
 
+from six import StringIO
+
 
 def _init_client(spec, require_token=False):
     if 'host' not in spec:
@@ -26,6 +28,8 @@ def _init_client(spec, require_token=False):
 
 def fetch_handler(spec, **kwargs):
     resource_type = spec.get('resource_type', 'file').lower()
+    taskInput = kwargs.get('task_input', {})
+    target = taskInput.get('target', 'filepath')
 
     if 'id' not in spec:
         raise Exception('Must pass a resource ID for girder inputs.')
@@ -44,12 +48,20 @@ def fetch_handler(spec, **kwargs):
     else:
         raise Exception('Invalid resource type: ' + resource_type)
 
-    return dest
+    if target == 'filepath':
+        return dest
+    elif target == 'memory':
+        with open(dest, 'rb') as fd:
+            return fd.read()
+    else:
+        raise Exception('Invalid Girder push target: ' + target)
 
 
 def push_handler(data, spec, **kwargs):
     parent_type = spec.get('parent_type', 'folder')
     name = spec.get('name', os.path.basename(data))
+    taskOutput = kwargs.get('task_output', {})
+    target = taskOutput.get('target', 'filepath')
     description = spec.get('description')
 
     if 'parent_id' not in spec:
@@ -57,14 +69,17 @@ def push_handler(data, spec, **kwargs):
 
     client = _init_client(spec, require_token=True)
 
-    if parent_type == 'folder':
-        item = client.createItem(
-            spec['parent_id'], name, description=description)
-        client.uploadFileToItem(item['_id'], data)
-    elif parent_type == 'item':
-        client.uploadFileToItem(spec['parent_id'], data)
+    if target == 'memory':
+        fd = StringIO(data)
+        client.uploadFile(parentId=spec['parent_id'], stream=fd, size=len(data),
+                          parentType=parent_type, name=name)
+    elif target == 'filepath':
+        size = os.path.getsize(data)
+        with open(data, 'rb') as fd:
+            client.uploadFile(parentId=spec['parent_id'], stream=fd, size=size,
+                              parentType=parent_type, name=name)
     else:
-        raise Exception('Invalid parent type: ' + parent_type)
+        raise Exception('Invalid Girder push target: ' + target)
 
 
 def load(params):

--- a/romanesco/plugins/girder_io/requirements.txt
+++ b/romanesco/plugins/girder_io/requirements.txt
@@ -1,1 +1,1 @@
-girder-client==1.0.1
+girder-client==1.1.0

--- a/romanesco/plugins/girder_io/tests/girder_io_test.py
+++ b/romanesco/plugins/girder_io/tests/girder_io_test.py
@@ -10,16 +10,15 @@ class TestGirderIo(unittest.TestCase):
 
     def setUp(self):
         self.task = {
-            "inputs": [{"name": "input", "type": "string", "format": "text"}],
-            "outputs": [{"name": "out", "type": "string", "format": "text"}],
-            "script": "out = input",
-            "mode": "python"
+            'inputs': [{'name': 'input', 'type': 'string', 'format': 'text'}],
+            'outputs': [{'name': 'out', 'type': 'string', 'format': 'text'}],
+            'script': 'out = input',
+            'mode': 'python'
         }
 
     def test_girder_io(self):
         file_uploaded = []
         upload_initialized = []
-        item_created = []
 
         @httmock.all_requests
         def girder_mock(url, request):
@@ -43,12 +42,6 @@ class TestGirderIo(unittest.TestCase):
                 upload_initialized.append(1)
                 return json.dumps({
                     '_id': 'upload_id'
-                })
-            elif url.path == api_root + '/item' and request.method == 'POST':
-                item_created.append(1)
-                return json.dumps({
-                    '_id': 'new_item_id',
-                    'name': 'test.txt'
                 })
             elif (url.path == api_root + '/file/chunk' and
                   request.method == 'POST'):
@@ -105,7 +98,99 @@ class TestGirderIo(unittest.TestCase):
 
             romanesco.run(self.task, inputs=inputs, outputs=outputs)
             self.assertEqual(file_uploaded, [1])
-            self.assertEqual(item_created, [1])
+            self.assertEqual(upload_initialized, [1])
+
+    def test_memory_targets(self):
+        upload_initialized = []
+        chunk_sent = []
+
+        @httmock.all_requests
+        def girder_mock(url, request):
+            api_root = '/girder/api/v1'
+            self.assertEqual(request.headers['Girder-Token'], 'foo')
+            self.assertEqual(url.scheme, 'http')
+            self.assertTrue(url.path.startswith(api_root), url.path)
+            self.assertEqual(url.netloc, 'localhost:8080')
+
+            if url.path == api_root + '/item/item_id/files':
+                return json.dumps([{
+                    'name': 'test.txt',
+                    '_id': 'file_id',
+                    'size': 13
+                }])
+            elif url.path == api_root + '/item/new_item_id/files':
+                return '[]'
+            elif url.path == api_root + '/file/file_id/download':
+                return 'file_contents'
+            elif url.path == api_root + '/file' and request.method == 'POST':
+                upload_initialized.append(1)
+                return json.dumps({
+                    '_id': 'upload_id'
+                })
+            elif (url.path == api_root + '/file/chunk' and
+                  request.method == 'POST'):
+                self.assertTrue('file_contents' in request.body)
+                chunk_sent.append(1)
+                return json.dumps({
+                    '_id': 'new_file_id',
+                    'name': 'test.txt'
+                })
+            else:
+                raise Exception('Unexpected %s request to %s.' % (
+                    request.method, url.path))
+
+        inputs = {
+            'input': {
+                'mode': 'girder',
+                'host': 'localhost',
+                'scheme': 'http',
+                'port': 8080,
+                'api_root': '/girder/api/v1',
+                'resource_type': 'item',
+                'id': 'item_id',
+                'type': 'string',
+                'format': 'text',
+                'name': 'test.txt',
+                'token': 'foo'
+            }
+        }
+
+        outputs = {
+            'out': {
+                'mode': 'girder',
+                'host': 'localhost',
+                'scheme': 'http',
+                'port': 8080,
+                'api_root': '/girder/api/v1',
+                'parent_type': 'item',
+                'parent_id': 'item_id',
+                'format': 'text',
+                'type': 'string',
+                'token': 'foo',
+                'name': 'hello_world.txt'
+            }
+        }
+
+        task = {
+            'inputs': [{
+                'name': 'input',
+                'type': 'string',
+                'format': 'text',
+                'target': 'memory'
+            }],
+            'outputs': [{
+                'name': 'out',
+                'type': 'string',
+                'format': 'text',
+                'target': 'memory'
+            }],
+            'script': 'out = input',
+            'mode': 'python'
+        }
+
+        with httmock.HTTMock(girder_mock):
+            outputs = romanesco.run(task, inputs=inputs, outputs=outputs)
+            self.assertEqual(chunk_sent, [1])
             self.assertEqual(upload_initialized, [1])
 
 


### PR DESCRIPTION
Before, we only supported filepath targets. For backward compatibility,
they remain the default, but one can now specify target="memory" for
fetching and pushing.