### PR TITLE
Girder IO utils

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -108,6 +108,7 @@ new item with the same name as the file), or into an existing item.
 
     <GIRDER_OUTPUT> ::= {
         "mode": "girder",
+        "token": <girder token used for authentication>,
         "parent_id": <the _id value of the folder or item to upload into>,
         "format": "text",
         "type": "string"
@@ -117,7 +118,6 @@ new item with the same name as the file), or into an existing item.
         (, "port": <the port of the girder server, default is 80 for http: and 443 for https:>)
         (, "api_root": <path to the girder REST API, default is "/api/v1")
         (, "scheme": <"http" or "https", default is "http">)
-        (, "token": <girder token used for authentication>)
         (, "parent_type": <"folder" or "item", default is "folder">)
     }
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -65,9 +65,15 @@ Girder IO
 * **Description:** This plugin adds new fetch and push modes called ``girder``. The
   fetch mode for inputs supports downloading folders, items, or files from a Girder
   server. Inputs can be downloaded anonymously (if they are public) or using an
-  authentication token. This data is always written to disk within the task's
-  temporary directory, and is always a ``string/text`` format since the data itself
-  is simply the path to the downloaded file or directory.
+  authentication token. The downloaded data is either written to disk and passed
+  as a file, or read into memory, depending on whether the corresponding task
+  input's ``target`` field is set to ``"filepath"`` or ``"memory"``. Likewise for
+  uploads, the value of the output variable is interpreted as a path to a file to
+  be uploaded if the task output ``target`` is set to ``filepath``. If it's set to
+  ``memory``, the value of the output variable becomes the contents of the uploaded
+  file. The URL to access the Girder API must be specified either as a full URL in
+  the ``api_url`` field, or in parts via the ``host``, ``port``, ``api_root``, and
+  ``scheme`` fields.
 
 .. code-block :: none
 
@@ -75,9 +81,10 @@ Girder IO
         "mode": "girder",
         "id": <the _id value of the resource to download>,
         "name": <the name of the resource to download>,
-        "host": <the hostname of the girder server>,
         "format": "text",
         "type": "string"
+        (, "api_url": <full URL to the API, can be used instead of scheme/host/port/api_root>)
+        (, "host": <the hostname of the girder server. Required if no api_url is passed>)
         (, "port": <the port of the girder server, default is 80 for http: and 443 for https:>)
         (, "api_root": <path to the girder REST API, default is "/api/v1")
         (, "scheme": <"http" or "https", default is "http">)
@@ -102,11 +109,12 @@ new item with the same name as the file), or into an existing item.
     <GIRDER_OUTPUT> ::= {
         "mode": "girder",
         "parent_id": <the _id value of the folder or item to upload into>,
-        "host": <the hostname of the girder server>,
         "format": "text",
         "type": "string"
         (, "name": <optionally override name of the file to upload>)
-        (, "port": <the port of the girder server, default is 80 for http and 443 for https>)
+        (, "api_url": <full URL to the API, can be used instead of scheme/host/port/api_root>)
+        (, "host": <the hostname of the girder server. Required if no api_url is passed>)
+        (, "port": <the port of the girder server, default is 80 for http: and 443 for https:>)
         (, "api_root": <path to the girder REST API, default is "/api/v1")
         (, "scheme": <"http" or "https", default is "http">)
         (, "token": <girder token used for authentication>)

--- a/romanesco/plugins/girder_io/__init__.py
+++ b/romanesco/plugins/girder_io/__init__.py
@@ -7,7 +7,7 @@ from six import StringIO
 
 def _init_client(spec, require_token=False):
     if 'api_url' in spec:
-        client = girder_client.GirderClient(api_url=spec['api_url'])
+        client = girder_client.GirderClient(apiUrl=spec['api_url'])
     elif 'host' in spec:
         scheme = spec.get('scheme', 'http')
         port = spec.get('port', {

--- a/romanesco/plugins/girder_io/__init__.py
+++ b/romanesco/plugins/girder_io/__init__.py
@@ -71,11 +71,14 @@ def push_handler(data, spec, **kwargs):
     client = _init_client(spec, require_token=True)
 
     if target == 'memory':
+        if not spec.get('name'):
+            raise Exception('Girder uploads from memory objects must '
+                            'explicitly pass a "name" field.')
         fd = StringIO(data)
         client.uploadFile(parentId=spec['parent_id'], stream=fd, size=len(data),
                           parentType=parent_type, name=spec['name'])
     elif target == 'filepath':
-        name = spec.get('name', os.path.basename(data))
+        name = spec.get('name') or os.path.basename(data)
         size = os.path.getsize(data)
         with open(data, 'rb') as fd:
             client.uploadFile(parentId=spec['parent_id'], stream=fd, size=size,

--- a/romanesco/plugins/girder_io/__init__.py
+++ b/romanesco/plugins/girder_io/__init__.py
@@ -6,22 +6,25 @@ from six import StringIO
 
 
 def _init_client(spec, require_token=False):
-    if 'host' not in spec:
-        raise Exception('Host key required for girder fetch mode')
-
-    scheme = spec.get('scheme', 'http')
-    port = spec.get('port', {
-        'http': 80,
-        'https': 443
-    }[scheme])
-    api_root = spec.get('api_root', '/api/v1')
-    client = girder_client.GirderClient(
-        host=spec['host'], scheme=scheme, apiRoot=api_root, port=port)
+    if 'api_url' in spec:
+        client = girder_client.GirderClient(api_url=spec['api_url'])
+    elif 'host' in spec:
+        scheme = spec.get('scheme', 'http')
+        port = spec.get('port', {
+            'http': 80,
+            'https': 443
+        }[scheme])
+        api_root = spec.get('api_root', '/api/v1')
+        client = girder_client.GirderClient(
+            host=spec['host'], scheme=scheme, apiRoot=api_root, port=port)
 
     if 'token' in spec:
         client.token = spec['token']
     elif require_token:
-        raise Exception('You must pass a token for girder authentication.')
+        raise Exception('You must pass a token for Girder authentication.')
+    else:
+        raise Exception('You must pass either an api_url or host key for '
+                        'Girder input and output bindings.')
 
     return client
 

--- a/romanesco/plugins/girder_io/requirements.txt
+++ b/romanesco/plugins/girder_io/requirements.txt
@@ -1,1 +1,1 @@
-girder-client==1.1.0
+girder-client==1.1.1

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,0 +1,97 @@
+from girder.api.rest import getApiUrl
+
+
+def girderInputSpec(resource, resourceType='file', name=None, token=None,
+                    dataType='string', dataFormat='text'):
+    """
+    Downstream plugins that are building romanesco jobs that use Girder IO
+    should use this to generate the input specs more easily.
+
+    :param resource: The resource document to be downloaded at runtime.
+    :type resource: dict
+    :param resourceType: The resource type to download for the input. Should
+        be "folder", "item", or "file".
+    :type resourceType: str
+    :param name: The name of the resource to download. If not passed, uses
+        the "name" field of the resource document.
+    :type name: str or None
+    :param token: The Girder token document or raw token string to use to
+        authenticate when downloading. Pass `None` for anonymous downloads.
+    :type token: dict, str, or None
+    :param dataType: The romanesco `type` field.
+    :type dataType: str
+    :param dataFormat: The romanesco `format` field.
+    :type dataFormat: str
+    """
+    if type(token) is dict:
+        token = token['_id']
+
+    return {
+        'mode': 'girder',
+        'api_url': getApiUrl(),
+        'token': token,
+        'id': str(resource['_id']),
+        'name': name or resource['name'],
+        'resource_type': resourceType,
+        'type': dataType,
+        'format': dataFormat
+    }
+
+
+def girderOutputSpec(parent, token, parentType='folder', name=None,
+                     dataType='string', dataFormat='text'):
+    """
+    Downstream plugins that are building romanesco jobs that use Girder IO
+    should use this to generate the output specs more easily.
+
+    :param parent: The parent to upload the data into (an item or folder).
+    :type parent: dict
+    :param token: The Girder token document or raw token string to use to
+        authenticate when uploading.
+    :type token: dict or str
+    :param parentType: The type of the parent object ("item" or "folder").
+    :type parentType: str
+    :param name: Name of the resource to use when uploading. Required if
+        the output target type is "memory". If the target is "filepath", uses
+        the basename of the file being uploaded by default.
+    :type name: str or None
+    :param dataType: The romanesco `type` field.
+    :type dataType: str
+    :param dataFormat: The romanesco `format` field.
+    :type dataFormat: str
+    """
+    if type(token) is dict:
+        token = token['_id']
+
+    return {
+        'mode': 'girder',
+        'api_url': getApiUrl(),
+        'token': token,
+        'name': name,
+        'parent_id': str(parent['_id']),
+        'parent_type': parentType,
+        'type': dataType,
+        'format': dataFormat
+    }
+
+
+def jobInfoSpec(job, token, logPrint=True):
+    """
+    Build the jobInfo specification for a romanesco task to write status and
+    log output back to a Girder job.
+
+    :param job: The job document representing the romanesco task.
+    :type job: dict
+    :param token: The token
+    :type token: str or dict
+    :param logPrint: Whether standard output from the job should be
+    """
+    if type(token) is dict:
+        token = token['_id']
+
+    return {
+        'method': 'PUT',
+        'url': '/'.join((getApiUrl(), 'job', str(job['_id']))),
+        'headers': {'Girder-Token': token},
+        'logPrint': logPrint
+    }


### PR DESCRIPTION
This depends on #186 .

This adds some much-needed utilities to the server-side plugin to reduce boilerplate for downstream girder plugins that need to build tasks with girder IO dependencies. Also, ported the girder IO mode to support the new `apiUrl` method of instantiating a `GirderClient`.