### PR TITLE
Make scala mode work like Python and R with variable injection

### DIFF
--- a/romanesco/plugins/scala/tests/scala_test.py
+++ b/romanesco/plugins/scala/tests/scala_test.py
@@ -28,14 +28,15 @@ class TestScalaMode(unittest.TestCase):
         task = {
             'mode': 'scala',
             'script': """
-println("Hello, " + args(0) + "!")
-val bufferedSource = io.Source.fromFile(args(1))
+val message = "Hello, " + foo + "!"
+val square = x * x
+val not_b = !b
+val bufferedSource = io.Source.fromFile(file)
 for (line <- bufferedSource.getLines) {
     val cols = line.split(",").map(_.trim)
     println(s"${cols(0)}|${cols(1)}|${cols(2)}")
 }
 """,
-            'scala_args': ['$input{foo}', '$input{file}'],
             'inputs': [
                 {
                     'id': 'foo',
@@ -43,17 +44,44 @@ for (line <- bufferedSource.getLines) {
                     'type': 'string'
                 },
                 {
+                    'id': 'x',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
                     'id': 'file',
                     'type': 'string',
                     'format': 'text',
                     'target': 'filepath'
+                },
+                {
+                    'id': 'b',
+                    'format': 'boolean',
+                    'type': 'boolean'
                 }
             ],
-            'outputs': [{
-                'id': '_stdout',
-                'format': 'text',
-                'type': 'string'
-            }]
+            'outputs': [
+                {
+                    'id': '_stdout',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'message',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'square',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
+                    'id': 'not_b',
+                    'format': 'boolean',
+                    'type': 'boolean'
+                }
+            ]
         }
 
         inputs = {
@@ -64,6 +92,14 @@ for (line <- bufferedSource.getLines) {
             'file': {
                 'format': 'text',
                 'data': 'a,  b, c\n1,\t2,3\n'
+            },
+            'x': {
+                'format': 'number',
+                'data': 12
+            },
+            'b': {
+                'format': 'boolean',
+                'data': True
             }
         }
 
@@ -71,7 +107,19 @@ for (line <- bufferedSource.getLines) {
 
         self.assertEqual(out, {
             '_stdout': {
-                'data': 'Hello, world!\na|b|c\n1|2|3\n',
+                'data': 'a|b|c\n1|2|3\n',
                 'format': 'text'
+            },
+            'message': {
+                'data': 'Hello, world!',
+                'format': 'text'
+            },
+            'square': {
+                'data': 144,
+                'format': 'number'
+            },
+            'not_b': {
+                'data': False,
+                'format': 'boolean'
             }
         })


### PR DESCRIPTION
See the test for an example of how this works.

The code now surrounds the Scala script with setup/teardown to allow the use of input variables in the script, and writes outputs to temporary files using `toString()` in Scala. This will enable string, number, and boolean types to be passed into and out of the Scala mode. I wanted to perform generic JSON serialization to handle things like Scala Map and List, but there is no built-in JSON serialization library for Scala.