### PR TITLE
Spark scala support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ before_install:
   - export SPARK_HOME=$HOME/spark-1.3.1-bin-hadoop2.4
   - export SPARK_MASTER_IP=localhost
   - if [ ! -f $SPARK_HOME/sbin/start-master.sh ] ; then curl -L https://www.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz | tar -zx -C ~ ; fi
+  - export PATH=$PATH:$SPARK_HOME/bin
+  - which spark-shell
   - $SPARK_HOME/sbin/start-master.sh
   - sleep 3
   - $SPARK_HOME/sbin/start-slave.sh worker1 spark://localhost:7077

--- a/romanesco/plugins/scala/__init__.py
+++ b/romanesco/plugins/scala/__init__.py
@@ -4,3 +4,4 @@ from . import executor
 
 def load(params):
     romanesco.register_executor('scala', executor.run)
+    romanesco.register_executor('spark.scala', executor.run_spark)

--- a/romanesco/plugins/scala/tests/scala_test.py
+++ b/romanesco/plugins/scala/tests/scala_test.py
@@ -123,3 +123,157 @@ for (line <- bufferedSource.getLines) {
                 'format': 'boolean'
             }
         })
+
+    def testSparkScalaMode(self):
+        task = {
+            'mode': 'spark.scala',
+            'script': """
+val textFile = sc.textFile(file)
+val first = textFile.first()
+val count = textFile.filter(line => line.contains("a")).count()
+val message = "Hello, " + foo + "!"
+val square = x * x
+val not_b = !b
+""",
+            'inputs': [
+                {
+                    'id': 'foo',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'x',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
+                    'id': 'file',
+                    'type': 'string',
+                    'format': 'text',
+                    'target': 'filepath'
+                },
+                {
+                    'id': 'b',
+                    'format': 'boolean',
+                    'type': 'boolean'
+                }
+            ],
+            'outputs': [
+                {
+                    'id': 'count',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
+                    'id': 'first',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'message',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'square',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
+                    'id': 'not_b',
+                    'format': 'boolean',
+                    'type': 'boolean'
+                }
+            ]
+        }
+
+        inputs = {
+            'foo': {
+                'format': 'text',
+                'data': 'world'
+            },
+            'file': {
+                'format': 'text',
+                'data': 'abc\n123\naba\n'
+            },
+            'x': {
+                'format': 'number',
+                'data': 12
+            },
+            'b': {
+                'format': 'boolean',
+                'data': True
+            }
+        }
+
+        out = romanesco.run(task, inputs=inputs)
+
+        self.assertEqual(out, {
+            'count': {
+                'data': 2,
+                'format': 'number'
+            },
+            'first': {
+                'data': 'abc',
+                'format': 'text'
+            },
+            'message': {
+                'data': 'Hello, world!',
+                'format': 'text'
+            },
+            'square': {
+                'data': 144,
+                'format': 'number'
+            },
+            'not_b': {
+                'data': False,
+                'format': 'boolean'
+            }
+        })
+
+    def testSparkMLLib(self):
+        task = {
+            'mode': 'spark.scala',
+            'script': """
+import org.apache.spark.mllib.clustering.{KMeans, KMeansModel}
+import org.apache.spark.mllib.linalg.Vectors
+
+// Load and parse the data
+val data = sc.textFile(file)
+val parsedData = data.map(s => Vectors.dense(s.split(',').map(_.toDouble))).cache()
+
+// Cluster the data into two classes using KMeans
+val numClusters = 2
+val numIterations = 20
+val clusters = KMeans.train(parsedData, numClusters, numIterations)
+
+// Evaluate clustering by computing Within Set Sum of Squared Errors
+val WSSSE = clusters.computeCost(parsedData)
+println("Within Set Sum of Squared Errors = " + WSSSE)
+""",
+            'inputs': [
+                {
+                    'id': 'file',
+                    'type': 'string',
+                    'format': 'text',
+                    'target': 'filepath'
+                }
+            ],
+            'outputs': [
+                {
+                    'id': 'WSSSE',
+                    'format': 'number',
+                    'type': 'number'
+                }
+            ]
+        }
+
+        inputs = {
+            'file': {
+                'format': 'text',
+                'data': '1,2,3\n4,5,6\n7,8,9\n'
+            }
+        }
+
+        out = romanesco.run(task, inputs=inputs)
+        self.assertTrue(out['WSSSE']['data'] < 20)

--- a/romanesco/plugins/scala/tests/scala_test.py
+++ b/romanesco/plugins/scala/tests/scala_test.py
@@ -28,14 +28,15 @@ class TestScalaMode(unittest.TestCase):
         task = {
             'mode': 'scala',
             'script': """
-println("Hello, " + args(0) + "!")
-val bufferedSource = io.Source.fromFile(args(1))
+val message = "Hello, " + foo + "!"
+val square = x * x
+val not_b = !b
+val bufferedSource = io.Source.fromFile(file)
 for (line <- bufferedSource.getLines) {
     val cols = line.split(",").map(_.trim)
     println(s"${cols(0)}|${cols(1)}|${cols(2)}")
 }
 """,
-            'scala_args': ['$input{foo}', '$input{file}'],
             'inputs': [
                 {
                     'id': 'foo',
@@ -43,17 +44,44 @@ for (line <- bufferedSource.getLines) {
                     'type': 'string'
                 },
                 {
+                    'id': 'x',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
                     'id': 'file',
                     'type': 'string',
                     'format': 'text',
                     'target': 'filepath'
+                },
+                {
+                    'id': 'b',
+                    'format': 'boolean',
+                    'type': 'boolean'
                 }
             ],
-            'outputs': [{
-                'id': '_stdout',
-                'format': 'text',
-                'type': 'string'
-            }]
+            'outputs': [
+                {
+                    'id': '_stdout',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'message',
+                    'format': 'text',
+                    'type': 'string'
+                },
+                {
+                    'id': 'square',
+                    'format': 'number',
+                    'type': 'number'
+                },
+                {
+                    'id': 'not_b',
+                    'format': 'boolean',
+                    'type': 'boolean'
+                }
+            ]
         }
 
         inputs = {
@@ -64,6 +92,14 @@ for (line <- bufferedSource.getLines) {
             'file': {
                 'format': 'text',
                 'data': 'a,  b, c\n1,\t2,3\n'
+            },
+            'x': {
+                'format': 'number',
+                'data': 12
+            },
+            'b': {
+                'format': 'boolean',
+                'data': True
             }
         }
 
@@ -71,7 +107,19 @@ for (line <- bufferedSource.getLines) {
 
         self.assertEqual(out, {
             '_stdout': {
-                'data': 'Hello, world!\na|b|c\n1|2|3\n',
+                'data': 'a|b|c\n1|2|3\n',
                 'format': 'text'
+            },
+            'message': {
+                'data': 'Hello, world!',
+                'format': 'text'
+            },
+            'square': {
+                'data': 144,
+                'format': 'number'
+            },
+            'not_b': {
+                'data': False,
+                'format': 'boolean'
             }
         })


### PR DESCRIPTION
Add `"spark.scala"` mode which is almost exactly like the `"scala"` mode but uses the `spark-shell` command instead of the `scala` command to execute the code. Also required an `exit(0)` call because `spark-shell` does not normally terminate on script completion.

Depends on #192.