### PR TITLE
Add several new job statuses

### DIFF
--- a/romanesco/__main__.py
+++ b/romanesco/__main__.py
@@ -1,7 +1,7 @@
 import romanesco
 from romanesco.format import conv_graph
 
-from .utils import JobManager
+from .utils import JobManager, JobStatus
 from celery import Celery
 
 app = None
@@ -23,6 +23,7 @@ def main():
                         url=jobInfo.get('url'), method=jobInfo.get('method'),
                         headers=jobInfo.get('headers')) as jm:
             kwargs['_job_manager'] = jm
+            kwargs['status'] = JobStatus.RUNNING
             retval = romanesco.run(*pargs, **kwargs)
         return retval
 

--- a/romanesco/utils.py
+++ b/romanesco/utils.py
@@ -21,6 +21,11 @@ class JobStatus(object):
     ERROR = 4
     CANCELED = 5
 
+    FETCHING_INPUT = 820
+    CONVERTING_INPUT = 821
+    CONVERTING_OUTPUT = 822
+    PUSHING_OUTPUT = 823
+
 
 class TerminalColor(object):
     """
@@ -34,7 +39,7 @@ class TerminalColor(object):
 
     @staticmethod
     def _color(tag, text):
-        return ''.join([tag, text, TerminalColor.ENDC])
+        return ''.join((tag, text, TerminalColor.ENDC))
 
     @staticmethod
     def error(text):
@@ -79,6 +84,7 @@ class JobManager(object):
         self.url = url
         self.headers = headers or {}
         self.interval = interval
+        self.status = None
 
         self._last = time.time()
         self._buf = ''
@@ -91,7 +97,6 @@ class JobManager(object):
             sys.stdout, sys.stderr = self, self
 
     def __enter__(self):
-        self.updateStatus(JobStatus.RUNNING)
         return self
 
     def __exit__(self, excType, excValue, tb):
@@ -175,7 +180,7 @@ class JobManager(object):
         :param status: The status to set on the job.
         :type status: JobStatus
         """
-        if not self.url:
+        if not self.url or status is None or status == self.status:
             return
 
         self._redirectPipes(False)

--- a/romanesco/utils.py
+++ b/romanesco/utils.py
@@ -183,6 +183,7 @@ class JobManager(object):
         if not self.url or status is None or status == self.status:
             return
 
+        self.status = status
         self._redirectPipes(False)
         requests.request(self.method.upper(), self.url, headers=self.headers,
                          data={'status': status}, allow_redirects=True)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -64,9 +64,9 @@ def schedule(event):
             'romanesco.run', job['args'], job['kwargs'])
 
         # Set the job status to queued and record the task ID from celery.
-        job['status'] = JobStatus.QUEUED
         job['taskId'] = asyncResult.task_id
-        ModelImporter.model('job', 'jobs').save(job)
+        ModelImporter.model('job', 'jobs').updateJob(
+            job, status=JobStatus.QUEUED)
 
 
 def validateSettings(event):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -276,7 +276,7 @@ with open(file) as f:
                 raise Exception('Unexpected url ' + repr(url))
 
         with httmock.HTTMock(fetchMock):
-            out = romanesco.run(
+            romanesco.run(
                 task, inputs=inputs, outputs=outputs, _job_manager=job_mgr,
                 status=JobStatus.RUNNING)
 

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -5,6 +5,8 @@ import romanesco
 import shutil
 import unittest
 
+from romanesco.utils import JobStatus
+
 _tmp = None
 
 
@@ -110,20 +112,18 @@ with open(file) as f:
             'script': 'y = x + "_suffix"\nfoo="bar"',
             'inputs': [{
                 'id': 'x',
-                'name': 'x',
-                'format': 'string',
+                'format': 'text',
                 'type': 'string',
                 'target': 'filepath',
                 'filename': 'override.txt'
             }],
             'outputs': [{
                 'id': 'y',
-                'name': 'y',
-                'format': 'string',
+                'format': 'text',
                 'type': 'string'
             }, {
                 'id': 'foo',
-                'format': 'string',
+                'format': 'text',
                 'type': 'string'
             }]
         }
@@ -131,21 +131,27 @@ with open(file) as f:
         inputs = {
             'x': {
                 'mode': 'http',
-                'url': 'https://foo.com/file.txt'
+                'url': 'https://foo.com/file.txt',
+                'format': 'text',
+                'type': 'string'
             }
         }
 
         outputs = {
             'foo': {
                 'mode': 'http',
-                'format': 'string',
+                'format': 'text',
+                'type': 'string',
                 'url': 'https://output.com/location.out',
                 'headers': {'foo': 'bar'},
                 'method': 'PUT'
             }
         }
 
+        job_mgr = romanesco.utils.JobManager(True, url='http://jobstatus/')
+
         received = []
+        status_changes = []
 
         @httmock.all_requests
         def fetchMock(url, request):
@@ -155,6 +161,10 @@ with open(file) as f:
             elif url.netloc == 'output.com' and url.path == '/location.out':
                 received.append(request.body)
                 return ''
+            elif (url.netloc == 'jobstatus' and url.path == '/' and
+                    request.method == 'PUT'):
+                status_changes.append(request.body)
+                return ''
             else:
                 raise Exception('Unexpected url ' + repr(url))
 
@@ -162,11 +172,20 @@ with open(file) as f:
             # Use user-specified filename
             out = romanesco.run(
                 task, inputs=copy.deepcopy(inputs), outputs=outputs,
-                cleanup=False, validate=False, auto_convert=False)
+                cleanup=False, _job_manager=job_mgr, status=JobStatus.RUNNING)
 
             val = out['y']['data']
             self.assertTrue(val.endswith('override.txt_suffix'))
             path = val[:-7]
+
+            # We should have received 3 status changes
+            expected_statuses = [
+                JobStatus.FETCHING_INPUT,
+                JobStatus.RUNNING,
+                JobStatus.PUSHING_OUTPUT
+            ]
+            self.assertEqual(status_changes, [
+                'status=%d' % i for i in expected_statuses])
 
             self.assertTrue(os.path.exists(path), path)
             with open(path) as f:
@@ -183,7 +202,6 @@ with open(file) as f:
 
             # Use automatically detected filename
             del task['inputs'][0]['filename']
-
             out = romanesco.run(
                 task, inputs=copy.deepcopy(inputs), cleanup=False,
                 validate=False, auto_convert=False)
@@ -210,3 +228,64 @@ with open(file) as f:
         outputs = romanesco.run(task)
         self.assertTrue('_tempdir' in outputs)
         self.assertRegexpMatches(outputs['_tempdir']['data'], _tmp + '.+')
+
+    def testConvertingStatus(self):
+        job_mgr = romanesco.utils.JobManager(True, url='http://jobstatus/')
+
+        status_changes = []
+
+        task = {
+            'mode': 'python',
+            'script': 'y = x',
+            'inputs': [{
+                'id': 'x',
+                'format': 'tsv',
+                'type': 'table'
+            }],
+            'outputs': [{
+                'id': 'y',
+                'format': 'tsv',
+                'type': 'table'
+            }]
+        }
+
+        inputs = {
+            'x': {
+                'mode': 'inline',
+                'data': 'a,b,c\nd,e,f\n',
+                'type': 'table',
+                'format': 'csv'
+            }
+        }
+
+        outputs = {
+            'y': {
+                'mode': 'inline',
+                'type': 'table',
+                'format': 'csv'
+            }
+        }
+
+        @httmock.all_requests
+        def fetchMock(url, request):
+            if (url.netloc == 'jobstatus' and url.path == '/' and
+                    request.method == 'PUT'):
+                status_changes.append(request.body)
+                return ''
+            else:
+                raise Exception('Unexpected url ' + repr(url))
+
+        with httmock.HTTMock(fetchMock):
+            out = romanesco.run(
+                task, inputs=inputs, outputs=outputs, _job_manager=job_mgr,
+                status=JobStatus.RUNNING)
+
+            # We should have received 3 status changes
+            expected_statuses = [
+                JobStatus.CONVERTING_INPUT,
+                JobStatus.RUNNING,
+                JobStatus.CONVERTING_OUTPUT,
+                JobStatus.PUSHING_OUTPUT
+            ]
+            self.assertEqual(status_changes, [
+                'status=%d' % i for i in expected_statuses])

--- a/web_client/js/JobDetailsExtensions.js
+++ b/web_client/js/JobDetailsExtensions.js
@@ -1,0 +1,22 @@
+girder.jobs_JobStatus.registerStatus({
+    ROMANESCO_FETCHING_INPUT: {
+        value: 820,
+        text: 'Fetching input',
+        icon: 'icon-download'
+    },
+    ROMANESCO_CONVERTING_INPUT: {
+        value: 821,
+        text: 'Converting input',
+        icon: 'icon-shuffle'
+    },
+    ROMANESCO_CONVERTING_OUTPUT: {
+        value: 822,
+        text: 'Converting output',
+        icon: 'icon-shuffle'
+    },
+    ROMANESCO_PUSHING_OUTPUT: {
+        value: 823,
+        text: 'Pushing output',
+        icon: 'icon-upload'
+    }
+});

--- a/web_client/stylesheets/jobDetails.styl
+++ b/web_client/stylesheets/jobDetails.styl
@@ -1,0 +1,7 @@
+.g-job-color-fetching-input, .g-job-color-pushing-output
+  background-color #89d2e2
+  color #333
+
+.g-job-color-converting-input, .g-job-color-converting-output
+  background-color #92f5b5
+  color white


### PR DESCRIPTION
We now send separate status flags for fetching, converting, and
pushing. This will help for tracking job performance in many
deployments.