### PR TITLE
Upgrade Flake8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage==4.0.3
 coveralls==0.5
-flake8==2.5.1
+flake8==2.5.2
 flake8-docstrings==0.2.4
 httmock==1.2.4
 lxml==3.4.4


### PR DESCRIPTION
This allows Flake8 to cleanly use the latest version of McCabe.