### PR TITLE
Update all route handlers to use describeRoute decorator

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -217,7 +217,6 @@ def load(info):  # noqa
 
         return asyncResult.get()
 
-    @access.public
     def getTaskId(jobId):
         # Get the celery task ID for this job.
         jobApi = info['apiRoot'].job

--- a/server/validator.py
+++ b/server/validator.py
@@ -1,6 +1,6 @@
 from girder.api import access
 from girder.api.rest import Resource
-from girder.api.describe import Description
+from girder.api.describe import Description, describeRoute
 
 
 class Validator(Resource):
@@ -10,12 +10,12 @@ class Validator(Resource):
         self.celeryApp = celeryApp
 
     @access.public
-    def find(self, params):
-        return self.celeryApp.send_task('romanesco.validators', [
-            params.get('type', None),
-            params.get('format', None)]).get()
-    find.description = (
+    @describeRoute(
         Description('List or search for validators.')
         .param('type', 'Find validators with this type.', required=False)
         .param('format', 'Find validators with this format.', required=False)
     )
+    def find(self, params):
+        return self.celeryApp.send_task('romanesco.validators', [
+            params.get('type', None),
+            params.get('format', None)]).get()


### PR DESCRIPTION
- Update all route handlers to use `@describeRoute`
- Remove access decorator from `getTaskId`
  - This is not an actual exposed route handler.
